### PR TITLE
Change Call- and BlockConfirmation to SidechainblockProposed and ParentchainblockProcessed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "14.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -581,7 +581,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -593,7 +593,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "log",
@@ -1311,7 +1311,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1396,7 +1396,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1413,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2067,7 +2067,7 @@ checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "hash-db",
  "log",
@@ -2084,7 +2084,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -2096,7 +2096,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -2108,7 +2108,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -2166,7 +2166,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2176,7 +2176,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -2187,7 +2187,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -2201,7 +2201,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "futures",
  "hash-db",
@@ -2226,7 +2226,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -2237,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2253,7 +2253,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "ruzstd",
  "zstd",
@@ -2262,7 +2262,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "backtrace",
 ]
@@ -2270,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -2291,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -2308,7 +2308,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -2320,7 +2320,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -2330,7 +2330,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "hash-db",
  "log",
@@ -2353,12 +2353,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 
 [[package]]
 name = "sp-storage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -2371,7 +2371,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -2387,7 +2387,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "erased-serde",
  "log",
@@ -2405,7 +2405,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -2419,7 +2419,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -2434,7 +2434,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -2445,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "14.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -581,7 +581,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -593,7 +593,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "log",
@@ -1311,7 +1311,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1396,7 +1396,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1413,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2067,7 +2067,7 @@ checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "hash-db",
  "log",
@@ -2084,7 +2084,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -2096,7 +2096,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -2108,7 +2108,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -2166,7 +2166,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2176,7 +2176,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -2187,7 +2187,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -2201,7 +2201,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "futures",
  "hash-db",
@@ -2226,7 +2226,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -2237,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2253,7 +2253,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "ruzstd",
  "zstd",
@@ -2262,7 +2262,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "backtrace",
 ]
@@ -2270,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -2291,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -2308,7 +2308,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -2320,7 +2320,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -2330,7 +2330,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "hash-db",
  "log",
@@ -2353,12 +2353,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 
 [[package]]
 name = "sp-storage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -2371,7 +2371,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -2387,7 +2387,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "erased-serde",
  "log",
@@ -2405,7 +2405,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -2419,7 +2419,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -2434,7 +2434,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -2445,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -2515,7 +2515,7 @@ dependencies = [
 [[package]]
 name = "substrate-fixed"
 version = "0.5.6"
-source = "git+https://github.com/encointer/substrate-fixed#b33d186888c60f38adafcfc0ec3a21aab263aef1"
+source = "git+https://github.com/encointer/substrate-fixed.git#b33d186888c60f38adafcfc0ec3a21aab263aef1"
 dependencies = [
  "parity-scale-codec",
  "typenum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "14.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -581,7 +581,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -593,7 +593,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "log",
@@ -1311,7 +1311,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1396,7 +1396,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1413,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2067,7 +2067,7 @@ checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "hash-db",
  "log",
@@ -2084,7 +2084,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -2096,7 +2096,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -2108,7 +2108,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -2166,7 +2166,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2176,7 +2176,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -2187,7 +2187,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -2201,7 +2201,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "futures",
  "hash-db",
@@ -2226,7 +2226,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -2237,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2253,7 +2253,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "ruzstd",
  "zstd",
@@ -2262,7 +2262,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "backtrace",
 ]
@@ -2270,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -2291,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -2308,7 +2308,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -2320,7 +2320,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -2330,7 +2330,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "hash-db",
  "log",
@@ -2353,12 +2353,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 
 [[package]]
 name = "sp-storage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -2371,7 +2371,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -2387,7 +2387,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "erased-serde",
  "log",
@@ -2405,7 +2405,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -2419,7 +2419,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -2434,7 +2434,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -2445,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",

--- a/teerex/src/benchmarking.rs
+++ b/teerex/src/benchmarking.rs
@@ -120,9 +120,9 @@ benchmarks! {
 		assert_latest_worker_update::<T>(&accounts[0], &shard)
 	}
 
-	// Benchmark `confirm_sidechainblock_proposed` with the worst possible conditions:
+	// Benchmark `confirm_proposed_sidechainblock` with the worst possible conditions:
 	// * sender enclave is registered
-	confirm_sidechainblock_proposed {
+	confirm_proposed_sidechainblock {
 		let accounts: Vec<T::AccountId> = generate_accounts::<T>(1);
 		add_enclaves_to_registry::<T>(&accounts);
 

--- a/teerex/src/benchmarking.rs
+++ b/teerex/src/benchmarking.rs
@@ -111,9 +111,9 @@ benchmarks! {
 		let req = Request { shard:H256::from_slice(&TEST4_SETUP.mrenclave), cyphertext: vec![1u8; 2000]};
 	}: _(RawOrigin::Signed(accounts[0].clone()), req)
 
-	// Benchmark `confirm_call` with the worst possible conditions:
+	// Benchmark `confirm_parentchainblock_processed` with the worst possible conditions:
 	// * sender enclave is registered
-	confirm_call {
+	confirm_parentchainblock_processed {
 		let accounts: Vec<T::AccountId> = generate_accounts::<T>(1);
 		add_enclaves_to_registry::<T>(&accounts);
 
@@ -126,9 +126,9 @@ benchmarks! {
 		assert_latest_worker_update::<T>(&accounts[0], &shard, ipfs_hash)
 	}
 
-	// Benchmark `confirm_block` with the worst possible conditions:
+	// Benchmark `confirm_sidechainblock_proposed` with the worst possible conditions:
 	// * sender enclave is registered
-	confirm_block {
+	confirm_sidechainblock_proposed {
 		let accounts: Vec<T::AccountId> = generate_accounts::<T>(1);
 		add_enclaves_to_registry::<T>(&accounts);
 

--- a/teerex/src/benchmarking.rs
+++ b/teerex/src/benchmarking.rs
@@ -111,14 +111,10 @@ benchmarks! {
 		let accounts: Vec<T::AccountId> = generate_accounts::<T>(1);
 		add_enclaves_to_registry::<T>(&accounts);
 
-		let shard: ShardIdentifier = H256::from_slice(&TEST4_SETUP.mrenclave);
 		let block_hash: H256 = [2; 32].into();
 		let merkle_root: H256 = [4; 32].into();
 
-	}: _(RawOrigin::Signed(accounts[0].clone()), shard, block_hash, merkle_root)
-	verify {
-		assert_latest_worker_update::<T>(&accounts[0], &shard)
-	}
+	}: _(RawOrigin::Signed(accounts[0].clone()), block_hash, merkle_root)
 
 	// Benchmark `confirm_proposed_sidechainblock` with the worst possible conditions:
 	// * sender enclave is registered

--- a/teerex/src/benchmarking.rs
+++ b/teerex/src/benchmarking.rs
@@ -105,9 +105,9 @@ benchmarks! {
 		let req = Request { shard:H256::from_slice(&TEST4_SETUP.mrenclave), cyphertext: vec![1u8; 2000]};
 	}: _(RawOrigin::Signed(accounts[0].clone()), req)
 
-	// Benchmark `confirm_parentchainblock_processed` with the worst possible conditions:
+	// Benchmark `confirm_processed_parentchainblock` with the worst possible conditions:
 	// * sender enclave is registered
-	confirm_parentchainblock_processed {
+	confirm_processed_parentchainblock {
 		let accounts: Vec<T::AccountId> = generate_accounts::<T>(1);
 		add_enclaves_to_registry::<T>(&accounts);
 

--- a/teerex/src/benchmarking.rs
+++ b/teerex/src/benchmarking.rs
@@ -119,9 +119,10 @@ benchmarks! {
 
 		let shard: ShardIdentifier = H256::from_slice(&TEST4_SETUP.mrenclave);
 		let block_hash: H256 = [2; 32].into();
+		let merkle_root: H256 = [4; 32].into();
 		let ipfs_hash: Vec<u8> = [3; 32].to_vec();
 
-	}: _(RawOrigin::Signed(accounts[0].clone()), shard, block_hash, ipfs_hash.clone())
+	}: _(RawOrigin::Signed(accounts[0].clone()), shard, block_hash, merkle_root, ipfs_hash.clone())
 	verify {
 		assert_latest_worker_update::<T>(&accounts[0], &shard, ipfs_hash)
 	}

--- a/teerex/src/benchmarking.rs
+++ b/teerex/src/benchmarking.rs
@@ -51,13 +51,7 @@ fn add_enclaves_to_registry<T: Config>(accounts: &[T::AccountId]) {
 	}
 }
 
-fn assert_latest_worker_update<T: Config>(
-	sender: &T::AccountId,
-	shard: &ShardIdentifier,
-	ipfs_hash: Vec<u8>,
-) {
-	assert_eq!(Teerex::<T>::latest_ipfs_hash(shard), ipfs_hash);
-
+fn assert_latest_worker_update<T: Config>(sender: &T::AccountId, shard: &ShardIdentifier) {
 	assert_eq!(Teerex::<T>::worker_for_shard(shard), Teerex::<T>::enclave_index(sender));
 }
 
@@ -120,11 +114,10 @@ benchmarks! {
 		let shard: ShardIdentifier = H256::from_slice(&TEST4_SETUP.mrenclave);
 		let block_hash: H256 = [2; 32].into();
 		let merkle_root: H256 = [4; 32].into();
-		let ipfs_hash: Vec<u8> = [3; 32].to_vec();
 
-	}: _(RawOrigin::Signed(accounts[0].clone()), shard, block_hash, merkle_root, ipfs_hash.clone())
+	}: _(RawOrigin::Signed(accounts[0].clone()), shard, block_hash, merkle_root)
 	verify {
-		assert_latest_worker_update::<T>(&accounts[0], &shard, ipfs_hash)
+		assert_latest_worker_update::<T>(&accounts[0], &shard)
 	}
 
 	// Benchmark `confirm_sidechainblock_proposed` with the worst possible conditions:
@@ -135,11 +128,10 @@ benchmarks! {
 
 		let shard: ShardIdentifier = H256::from_slice(&TEST4_SETUP.mrenclave);
 		let block_hash: H256 = [2; 32].into();
-		let ipfs_hash: Vec<u8> = [3; 32].to_vec();
 
-	}: _(RawOrigin::Signed(accounts[0].clone()), shard, block_hash, ipfs_hash.clone())
+	}: _(RawOrigin::Signed(accounts[0].clone()), shard, block_hash)
 	verify {
-		assert_latest_worker_update::<T>(&accounts[0], &shard, ipfs_hash)
+		assert_latest_worker_update::<T>(&accounts[0], &shard)
 	}
 }
 

--- a/teerex/src/lib.rs
+++ b/teerex/src/lib.rs
@@ -179,7 +179,7 @@ decl_module! {
 
 		// the integritee-service calls this function for every processed parentchainblock to confirm a state update
 		#[weight = (<T as Config>::WeightInfo::confirm_parentchainblock_processed(), DispatchClass::Normal, Pays::Yes)]
-		pub fn confirm_parentchainblock_processed(origin, shard_id: ShardIdentifier, block_hash: H256, trusted_calls_merkle_root: H256) -> DispatchResult {
+		pub fn confirm_parentchainblock_processed(origin, shard_id: ShardIdentifier, block_hash: H256, trusted_calls_merkle_root: H256, ipfs_hash: Vec<u8>) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 			Self::is_registered_enclave(&sender)?;
 			let sender_index = Self::enclave_index(&sender);
@@ -194,7 +194,7 @@ decl_module! {
 
 		// the integritee-service calls this function for every produced sidechainblock
 		#[weight = (<T as Config>::WeightInfo::confirm_sidechainblock_proposed(), DispatchClass::Normal, Pays::Yes)]
-		pub fn confirm_sidechainblock_proposed(origin, shard_id: ShardIdentifier, block_hash: H256) -> DispatchResult {
+		pub fn confirm_sidechainblock_proposed(origin, shard_id: ShardIdentifier, block_hash: H256, ipfs_hash: Vec<u8>) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 			Self::is_registered_enclave(&sender)?;
 			let sender_index = Self::enclave_index(&sender);

--- a/teerex/src/lib.rs
+++ b/teerex/src/lib.rs
@@ -106,7 +106,6 @@ decl_storage! {
 		pub EnclaveRegistry get(fn enclave): map hasher(blake2_128_concat) u64 => Enclave<T::AccountId, Vec<u8>>;
 		pub EnclaveCount get(fn enclave_count): u64;
 		pub EnclaveIndex get(fn enclave_index): map hasher(blake2_128_concat) T::AccountId => u64;
-		pub LatestIpfsHash get(fn latest_ipfs_hash) : map hasher(blake2_128_concat) ShardIdentifier => Vec<u8>;
 		// enclave index of the worker that recently committed an update
 		pub WorkerForShard get(fn worker_for_shard) : map hasher(blake2_128_concat) ShardIdentifier => u64;
 		pub ExecutedCalls get(fn confirmed_calls): map hasher(blake2_128_concat) H256 => u64;

--- a/teerex/src/lib.rs
+++ b/teerex/src/lib.rs
@@ -91,7 +91,7 @@ decl_event!(
 		ShieldFunds(Vec<u8>),
 		UnshieldedFunds(AccountId),
 		ParentchainBlockProcessed(AccountId, H256, H256),
-		SidechainBlockProposed(AccountId, H256),
+		ProposedSidechainBlock(AccountId, H256),
 	}
 );
 
@@ -189,15 +189,15 @@ decl_module! {
 		}
 
 		// the integritee-service calls this function for every produced sidechainblock
-		#[weight = (<T as Config>::WeightInfo::confirm_sidechainblock_proposed(), DispatchClass::Normal, Pays::Yes)]
-		pub fn confirm_sidechainblock_proposed(origin, shard_id: ShardIdentifier, block_hash: H256) -> DispatchResult {
+		#[weight = (<T as Config>::WeightInfo::confirm_proposed_sidechainblock(), DispatchClass::Normal, Pays::Yes)]
+		pub fn confirm_proposed_sidechainblock(origin, shard_id: ShardIdentifier, block_hash: H256) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 			Self::is_registered_enclave(&sender)?;
 			let sender_index = Self::enclave_index(&sender);
 			ensure!(<EnclaveRegistry::<T>>::get(sender_index).mr_enclave.encode() == shard_id.encode(),<Error<T>>::WrongMrenclaveForShard);
 			<WorkerForShard>::insert(shard_id, sender_index);
 			log::debug!("sidechain block confirmed with shard {:?}, block hash {:?}", shard_id, block_hash);
-			Self::deposit_event(RawEvent::SidechainBlockProposed(sender, block_hash));
+			Self::deposit_event(RawEvent::ProposedSidechainBlock(sender, block_hash));
 			Ok(())
 		}
 

--- a/teerex/src/lib.rs
+++ b/teerex/src/lib.rs
@@ -110,7 +110,7 @@ decl_storage! {
 		pub LatestIpfsHash get(fn latest_ipfs_hash) : map hasher(blake2_128_concat) ShardIdentifier => Vec<u8>;
 		// enclave index of the worker that recently committed an update
 		pub WorkerForShard get(fn worker_for_shard) : map hasher(blake2_128_concat) ShardIdentifier => u64;
-		pub ConfirmedCalls get(fn confirmed_calls): map hasher(blake2_128_concat) H256 => u64;
+		pub ExecutedCalls get(fn confirmed_calls): map hasher(blake2_128_concat) H256 => u64;
 		pub AllowSGXDebugMode get(fn allow_sgx_debug_mode) config(allow_sgx_debug_mode): bool;
 	}
 }
@@ -226,16 +226,16 @@ decl_module! {
 			let sender_index = <EnclaveIndex<T>>::get(sender);
 			ensure!(<EnclaveRegistry::<T>>::get(sender_index).mr_enclave.encode() == bonding_account.encode(),<Error<T>>::WrongMrenclaveForBondingAccount);
 
-			if !<ConfirmedCalls>::contains_key(call_hash) {
+			if !<ExecutedCalls>::contains_key(call_hash) {
 				log::info!("First confirmation for call: {:?}", call_hash);
 				T::Currency::transfer(&bonding_account, &public_account, amount, ExistenceRequirement::AllowDeath)?;
-				<ConfirmedCalls>::insert(call_hash, 0);
+				<ExecutedCalls>::insert(call_hash, 0);
 				Self::deposit_event(RawEvent::UnshieldedFunds(public_account));
 			} else {
 				log::info!("Second confirmation for call: {:?}", call_hash);
 			}
 
-			<ConfirmedCalls>::mutate(call_hash, |confirmations| {*confirmations += 1 });
+			<ExecutedCalls>::mutate(call_hash, |confirmations| {*confirmations += 1 });
 			Ok(())
 		}
 	}

--- a/teerex/src/lib.rs
+++ b/teerex/src/lib.rs
@@ -185,7 +185,7 @@ decl_module! {
 			Ok(())
 		}
 
-		// the integritee worker calls this function for every produced sidechainblock
+		// the integritee worker calls this function for every proposed sidechainblock
 		#[weight = (<T as Config>::WeightInfo::confirm_proposed_sidechainblock(), DispatchClass::Normal, Pays::Yes)]
 		pub fn confirm_proposed_sidechainblock(origin, shard_id: ShardIdentifier, block_hash: H256) -> DispatchResult {
 			let sender = ensure_signed(origin)?;

--- a/teerex/src/lib.rs
+++ b/teerex/src/lib.rs
@@ -91,7 +91,7 @@ decl_event!(
 		Forwarded(ShardIdentifier),
 		ShieldFunds(Vec<u8>),
 		UnshieldedFunds(AccountId),
-		ParentchainBlockProcessed(AccountId, H256),
+		ParentchainBlockProcessed(AccountId, H256, H256),
 		SidechainBlockProposed(AccountId, H256),
 	}
 );
@@ -187,7 +187,7 @@ decl_module! {
 			<LatestIpfsHash>::insert(shard_id, ipfs_hash.clone());
 			<WorkerForShard>::insert(shard_id, sender_index);
 			log::debug!("call confirmed with shard {:?}, block hash {:?}, ipfs_hash {:?}", shard_id, block_hash, ipfs_hash);
-			Self::deposit_event(RawEvent::ParentchainBlockProcessed(sender, block_hash));
+			Self::deposit_event(RawEvent::ParentchainBlockProcessed(sender, block_hash, trusted_calls_merkle_root));
 			Self::deposit_event(RawEvent::UpdatedIpfsHash(shard_id, sender_index, ipfs_hash));
 			Ok(())
 		}

--- a/teerex/src/lib.rs
+++ b/teerex/src/lib.rs
@@ -227,12 +227,12 @@ decl_module! {
 			ensure!(<EnclaveRegistry::<T>>::get(sender_index).mr_enclave.encode() == bonding_account.encode(),<Error<T>>::WrongMrenclaveForBondingAccount);
 
 			if !<ExecutedCalls>::contains_key(call_hash) {
-				log::info!("First confirmation for call: {:?}", call_hash);
+				log::info!("Executing unshielding call: {:?}", call_hash);
 				T::Currency::transfer(&bonding_account, &public_account, amount, ExistenceRequirement::AllowDeath)?;
 				<ExecutedCalls>::insert(call_hash, 0);
 				Self::deposit_event(RawEvent::UnshieldedFunds(public_account));
 			} else {
-				log::info!("Second confirmation for call: {:?}", call_hash);
+				log::info!("Already executed unshielding call: {:?}", call_hash);
 			}
 
 			<ExecutedCalls>::mutate(call_hash, |confirmations| {*confirmations += 1 });

--- a/teerex/src/lib.rs
+++ b/teerex/src/lib.rs
@@ -177,9 +177,9 @@ decl_module! {
 			Ok(())
 		}
 
-		// the integritee-service calls this function for every processed call to confirm a state update
+		// the integritee-service calls this function for every processed parentchainblock to confirm a state update
 		#[weight = (<T as Config>::WeightInfo::confirm_parentchainblock_processed(), DispatchClass::Normal, Pays::Yes)]
-		pub fn confirm_parentchainblock_processed(origin, shard_id: ShardIdentifier, block_hash: H256, trusted_calls_merkle_root: H256, ipfs_hash: Vec<u8>) -> DispatchResult {
+		pub fn confirm_parentchainblock_processed(origin, shard_id: ShardIdentifier, block_hash: H256, trusted_calls_merkle_root: H256) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 			Self::is_registered_enclave(&sender)?;
 			let sender_index = Self::enclave_index(&sender);
@@ -192,9 +192,9 @@ decl_module! {
 			Ok(())
 		}
 
-		// the integritee-service calls this function for every processed block to confirm a state update
+		// the integritee-service calls this function for every produced sidechainblock
 		#[weight = (<T as Config>::WeightInfo::confirm_sidechainblock_proposed(), DispatchClass::Normal, Pays::Yes)]
-		pub fn confirm_sidechainblock_proposed(origin, shard_id: ShardIdentifier, block_hash: H256, ipfs_hash: Vec<u8>) -> DispatchResult {
+		pub fn confirm_sidechainblock_proposed(origin, shard_id: ShardIdentifier, block_hash: H256) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 			Self::is_registered_enclave(&sender)?;
 			let sender_index = Self::enclave_index(&sender);

--- a/teerex/src/lib.rs
+++ b/teerex/src/lib.rs
@@ -175,7 +175,7 @@ decl_module! {
 			Ok(())
 		}
 
-		// the integritee worker calls this function for every processed parentchainblock to confirm a state update
+		/// The integritee worker calls this function for every processed parentchainblock to confirm a state update.
 		#[weight = (<T as Config>::WeightInfo::confirm_processed_parentchainblock(), DispatchClass::Normal, Pays::Yes)]
 		pub fn confirm_processed_parentchainblock(origin, block_hash: H256, trusted_calls_merkle_root: H256) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
@@ -185,7 +185,7 @@ decl_module! {
 			Ok(())
 		}
 
-		// the integritee worker calls this function for every proposed sidechainblock
+		/// The integritee worker calls this function for every proposed sidechainblock.
 		#[weight = (<T as Config>::WeightInfo::confirm_proposed_sidechainblock(), DispatchClass::Normal, Pays::Yes)]
 		pub fn confirm_proposed_sidechainblock(origin, shard_id: ShardIdentifier, block_hash: H256) -> DispatchResult {
 			let sender = ensure_signed(origin)?;

--- a/teerex/src/lib.rs
+++ b/teerex/src/lib.rs
@@ -177,13 +177,10 @@ decl_module! {
 
 		// the integritee worker calls this function for every processed parentchainblock to confirm a state update
 		#[weight = (<T as Config>::WeightInfo::confirm_processed_parentchainblock(), DispatchClass::Normal, Pays::Yes)]
-		pub fn confirm_processed_parentchainblock(origin, shard_id: ShardIdentifier, block_hash: H256, trusted_calls_merkle_root: H256) -> DispatchResult {
+		pub fn confirm_processed_parentchainblock(origin, block_hash: H256, trusted_calls_merkle_root: H256) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 			Self::is_registered_enclave(&sender)?;
-			let sender_index = Self::enclave_index(&sender);
-			ensure!(<EnclaveRegistry::<T>>::get(sender_index).mr_enclave.encode() == shard_id.encode(), <Error<T>>::WrongMrenclaveForShard);
-			<WorkerForShard>::insert(shard_id, sender_index);
-			log::debug!("parentchain block confirmed with shard {:?}, block hash {:?}", shard_id, block_hash);
+			log::debug!("Processed parentchain block confirmed for mrenclave {:?}, block hash {:?}", sender, block_hash);
 			Self::deposit_event(RawEvent::ProcessedParentchainBlock(sender, block_hash, trusted_calls_merkle_root));
 			Ok(())
 		}
@@ -196,7 +193,7 @@ decl_module! {
 			let sender_index = Self::enclave_index(&sender);
 			ensure!(<EnclaveRegistry::<T>>::get(sender_index).mr_enclave.encode() == shard_id.encode(),<Error<T>>::WrongMrenclaveForShard);
 			<WorkerForShard>::insert(shard_id, sender_index);
-			log::debug!("sidechain block confirmed with shard {:?}, block hash {:?}", shard_id, block_hash);
+			log::debug!("Proposed sidechain block confirmed with shard {:?}, block hash {:?}", shard_id, block_hash);
 			Self::deposit_event(RawEvent::ProposedSidechainBlock(sender, block_hash));
 			Ok(())
 		}

--- a/teerex/src/lib.rs
+++ b/teerex/src/lib.rs
@@ -87,7 +87,6 @@ decl_event!(
 	{
 		AddedEnclave(AccountId, Vec<u8>),
 		RemovedEnclave(AccountId),
-		UpdatedIpfsHash(ShardIdentifier, u64, Vec<u8>),
 		Forwarded(ShardIdentifier),
 		ShieldFunds(Vec<u8>),
 		UnshieldedFunds(AccountId),

--- a/teerex/src/lib.rs
+++ b/teerex/src/lib.rs
@@ -175,7 +175,7 @@ decl_module! {
 			Ok(())
 		}
 
-		// the integritee-service calls this function for every processed parentchainblock to confirm a state update
+		// the integritee worker calls this function for every processed parentchainblock to confirm a state update
 		#[weight = (<T as Config>::WeightInfo::confirm_processed_parentchainblock(), DispatchClass::Normal, Pays::Yes)]
 		pub fn confirm_processed_parentchainblock(origin, shard_id: ShardIdentifier, block_hash: H256, trusted_calls_merkle_root: H256) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
@@ -188,7 +188,7 @@ decl_module! {
 			Ok(())
 		}
 
-		// the integritee-service calls this function for every produced sidechainblock
+		// the integritee worker calls this function for every produced sidechainblock
 		#[weight = (<T as Config>::WeightInfo::confirm_proposed_sidechainblock(), DispatchClass::Normal, Pays::Yes)]
 		pub fn confirm_proposed_sidechainblock(origin, shard_id: ShardIdentifier, block_hash: H256) -> DispatchResult {
 			let sender = ensure_signed(origin)?;

--- a/teerex/src/lib.rs
+++ b/teerex/src/lib.rs
@@ -179,31 +179,27 @@ decl_module! {
 
 		// the integritee-service calls this function for every processed parentchainblock to confirm a state update
 		#[weight = (<T as Config>::WeightInfo::confirm_parentchainblock_processed(), DispatchClass::Normal, Pays::Yes)]
-		pub fn confirm_parentchainblock_processed(origin, shard_id: ShardIdentifier, block_hash: H256, trusted_calls_merkle_root: H256, ipfs_hash: Vec<u8>) -> DispatchResult {
+		pub fn confirm_parentchainblock_processed(origin, shard_id: ShardIdentifier, block_hash: H256, trusted_calls_merkle_root: H256) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 			Self::is_registered_enclave(&sender)?;
 			let sender_index = Self::enclave_index(&sender);
 			ensure!(<EnclaveRegistry::<T>>::get(sender_index).mr_enclave.encode() == shard_id.encode(), <Error<T>>::WrongMrenclaveForShard);
-			<LatestIpfsHash>::insert(shard_id, ipfs_hash.clone());
 			<WorkerForShard>::insert(shard_id, sender_index);
-			log::debug!("call confirmed with shard {:?}, block hash {:?}, ipfs_hash {:?}", shard_id, block_hash, ipfs_hash);
+			log::debug!("parentchain block confirmed with shard {:?}, block hash {:?}", shard_id, block_hash);
 			Self::deposit_event(RawEvent::ParentchainBlockProcessed(sender, block_hash, trusted_calls_merkle_root));
-			Self::deposit_event(RawEvent::UpdatedIpfsHash(shard_id, sender_index, ipfs_hash));
 			Ok(())
 		}
 
 		// the integritee-service calls this function for every produced sidechainblock
 		#[weight = (<T as Config>::WeightInfo::confirm_sidechainblock_proposed(), DispatchClass::Normal, Pays::Yes)]
-		pub fn confirm_sidechainblock_proposed(origin, shard_id: ShardIdentifier, block_hash: H256, ipfs_hash: Vec<u8>) -> DispatchResult {
+		pub fn confirm_sidechainblock_proposed(origin, shard_id: ShardIdentifier, block_hash: H256) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 			Self::is_registered_enclave(&sender)?;
 			let sender_index = Self::enclave_index(&sender);
 			ensure!(<EnclaveRegistry::<T>>::get(sender_index).mr_enclave.encode() == shard_id.encode(),<Error<T>>::WrongMrenclaveForShard);
-			<LatestIpfsHash>::insert(shard_id, ipfs_hash.clone());
 			<WorkerForShard>::insert(shard_id, sender_index);
-			log::debug!("block confirmed with shard {:?}, block hash {:?}, ipfs_hash {:?}", shard_id, block_hash, ipfs_hash);
+			log::debug!("sidechain block confirmed with shard {:?}, block hash {:?}", shard_id, block_hash);
 			Self::deposit_event(RawEvent::SidechainBlockProposed(sender, block_hash));
-			Self::deposit_event(RawEvent::UpdatedIpfsHash(shard_id, sender_index, ipfs_hash));
 			Ok(())
 		}
 

--- a/teerex/src/tests/tests.rs
+++ b/teerex/src/tests/tests.rs
@@ -257,17 +257,8 @@ fn update_ipfs_hash_works() {
 			shard.clone(),
 			block_hash.clone(),
 			merkle_root.clone(),
-			ipfs_hash.as_bytes().to_vec()
 		));
-		assert_eq!(Teerex::latest_ipfs_hash(shard.clone()), ipfs_hash.as_bytes().to_vec());
 		assert_eq!(Teerex::worker_for_shard(shard.clone()), 1u64);
-
-		let expected_event = Event::Teerex(RawEvent::UpdatedIpfsHash(
-			shard.clone(),
-			1,
-			ipfs_hash.as_bytes().to_vec(),
-		));
-		assert!(System::events().iter().any(|a| a.event == expected_event));
 
 		let expected_event =
 			Event::Teerex(RawEvent::ParentchainBlockProcessed(signer, block_hash, merkle_root));
@@ -278,7 +269,6 @@ fn update_ipfs_hash_works() {
 #[test]
 fn ipfs_update_from_unregistered_enclave_fails() {
 	new_test_ext().execute_with(|| {
-		let ipfs_hash = "QmYY9U7sQzBYe79tVfiMyJ4prEJoJRWCD8t85j9qjssS9y";
 		let signer = get_signer(TEST4_SIGNER_PUB);
 		assert_err!(
 			Teerex::confirm_parentchainblock_processed(
@@ -286,7 +276,6 @@ fn ipfs_update_from_unregistered_enclave_fails() {
 				H256::default(),
 				H256::default(),
 				H256::default(),
-				ipfs_hash.as_bytes().to_vec()
 			),
 			Error::<Test>::EnclaveIsNotRegistered
 		);
@@ -639,7 +628,6 @@ fn verify_unshield_funds_from_enclave_not_bonding_account_fails() {
 fn confirm_confirm_parentchainblock_processed_works_for_correct_shard() {
 	new_test_ext().execute_with(|| {
 		Timestamp::set_timestamp(TEST7_TIMESTAMP);
-		let ipfs_hash = "QmYY9U7sQzBYe79tVfiMyJ4prEJoJRWCD8t85j9qjssS9y";
 		let block_hash = H256::default();
 		let merkle_root = H256::default();
 		let signer7 = get_signer(TEST7_SIGNER_PUB);
@@ -658,15 +646,7 @@ fn confirm_confirm_parentchainblock_processed_works_for_correct_shard() {
 			shard7.clone(),
 			block_hash.clone(),
 			merkle_root.clone(),
-			ipfs_hash.as_bytes().to_vec()
 		));
-
-		let expected_event = Event::Teerex(RawEvent::UpdatedIpfsHash(
-			shard7.clone(),
-			1,
-			ipfs_hash.as_bytes().to_vec(),
-		));
-		assert!(System::events().iter().any(|a| a.event == expected_event));
 
 		let expected_event =
 			Event::Teerex(RawEvent::ParentchainBlockProcessed(signer7, block_hash, merkle_root));
@@ -678,7 +658,6 @@ fn confirm_confirm_parentchainblock_processed_works_for_correct_shard() {
 fn verify_confirm_parentchainblock_processed_from_shards_neq_mrenclave_fails() {
 	new_test_ext().execute_with(|| {
 		Timestamp::set_timestamp(TEST7_TIMESTAMP);
-		let ipfs_hash = "QmYY9U7sQzBYe79tVfiMyJ4prEJoJRWCD8t85j9qjssS9y";
 		let block_hash = H256::default();
 		let merkle_root = H256::default();
 		let signer7 = get_signer(TEST7_SIGNER_PUB);
@@ -697,7 +676,6 @@ fn verify_confirm_parentchainblock_processed_from_shards_neq_mrenclave_fails() {
 				shard4,
 				block_hash,
 				merkle_root,
-				ipfs_hash.as_bytes().to_vec()
 			),
 			Error::<Test>::WrongMrenclaveForShard
 		);
@@ -708,7 +686,6 @@ fn verify_confirm_parentchainblock_processed_from_shards_neq_mrenclave_fails() {
 fn confirm_sidechainblock_proposed_works_for_correct_shard() {
 	new_test_ext().execute_with(|| {
 		Timestamp::set_timestamp(TEST7_TIMESTAMP);
-		let ipfs_hash = "QmYY9U7sQzBYe79tVfiMyJ4prEJoJRWCD8t85j9qjssS9y";
 		let block_hash = H256::default();
 		let signer7 = get_signer(TEST7_SIGNER_PUB);
 		let shard7 = H256::from_slice(&TEST7_MRENCLAVE);
@@ -725,15 +702,7 @@ fn confirm_sidechainblock_proposed_works_for_correct_shard() {
 			Origin::signed(signer7.clone()),
 			shard7.clone(),
 			block_hash.clone(),
-			ipfs_hash.as_bytes().to_vec()
 		));
-
-		let expected_event = Event::Teerex(RawEvent::UpdatedIpfsHash(
-			shard7.clone(),
-			1,
-			ipfs_hash.as_bytes().to_vec(),
-		));
-		assert!(System::events().iter().any(|a| a.event == expected_event));
 
 		let expected_event = Event::Teerex(RawEvent::SidechainBlockProposed(signer7, block_hash));
 		assert!(System::events().iter().any(|a| a.event == expected_event));
@@ -744,7 +713,6 @@ fn confirm_sidechainblock_proposed_works_for_correct_shard() {
 fn verify_confirm_sidechainblock_proposed_from_shard_neq_mrenclave_fails() {
 	new_test_ext().execute_with(|| {
 		Timestamp::set_timestamp(TEST7_TIMESTAMP);
-		let ipfs_hash = "QmYY9U7sQzBYe79tVfiMyJ4prEJoJRWCD8t85j9qjssS9y";
 		let block_hash = H256::default();
 		let signer7 = get_signer(TEST7_SIGNER_PUB);
 		let shard4 = H256::from_slice(&TEST4_MRENCLAVE);
@@ -762,7 +730,6 @@ fn verify_confirm_sidechainblock_proposed_from_shard_neq_mrenclave_fails() {
 				Origin::signed(signer7.clone()),
 				shard4.clone(),
 				block_hash.clone(),
-				ipfs_hash.as_bytes().to_vec()
 			),
 			Error::<Test>::WrongMrenclaveForShard
 		);

--- a/teerex/src/tests/tests.rs
+++ b/teerex/src/tests/tests.rs
@@ -17,7 +17,7 @@
 
 //use super::*;
 use crate::{
-	mock::*, ConfirmedCalls, Enclave, EnclaveRegistry, Error, RawEvent, Request, ShardIdentifier,
+	mock::*, Enclave, EnclaveRegistry, Error, ExecutedCalls, RawEvent, Request, ShardIdentifier,
 };
 use frame_support::{assert_err, assert_ok, IterableStorageMap, StorageMap};
 use ias_verify::SgxBuildMode;
@@ -340,7 +340,7 @@ fn unshield_is_only_executed_once_for_the_same_call_hash() {
 		)
 		.is_ok());
 
-		assert_eq!(<ConfirmedCalls>::get(call_hash), 2)
+		assert_eq!(<ExecutedCalls>::get(call_hash), 2)
 	})
 }
 #[test]

--- a/teerex/src/tests/tests.rs
+++ b/teerex/src/tests/tests.rs
@@ -683,7 +683,7 @@ fn verify_confirm_parentchainblock_processed_from_shards_neq_mrenclave_fails() {
 }
 
 #[test]
-fn confirm_sidechainblock_proposed_works_for_correct_shard() {
+fn confirm_proposed_sidechainblock_works_for_correct_shard() {
 	new_test_ext().execute_with(|| {
 		Timestamp::set_timestamp(TEST7_TIMESTAMP);
 		let block_hash = H256::default();
@@ -698,19 +698,19 @@ fn confirm_sidechainblock_proposed_works_for_correct_shard() {
 		));
 		assert_eq!(Teerex::enclave_count(), 1);
 
-		assert_ok!(Teerex::confirm_sidechainblock_proposed(
+		assert_ok!(Teerex::confirm_proposed_sidechainblock(
 			Origin::signed(signer7.clone()),
 			shard7.clone(),
 			block_hash.clone(),
 		));
 
-		let expected_event = Event::Teerex(RawEvent::SidechainBlockProposed(signer7, block_hash));
+		let expected_event = Event::Teerex(RawEvent::ProposedSidechainBlock(signer7, block_hash));
 		assert!(System::events().iter().any(|a| a.event == expected_event));
 	})
 }
 
 #[test]
-fn verify_confirm_sidechainblock_proposed_from_shard_neq_mrenclave_fails() {
+fn verify_confirm_proposed_sidechainblock_from_shard_neq_mrenclave_fails() {
 	new_test_ext().execute_with(|| {
 		Timestamp::set_timestamp(TEST7_TIMESTAMP);
 		let block_hash = H256::default();
@@ -726,7 +726,7 @@ fn verify_confirm_sidechainblock_proposed_from_shard_neq_mrenclave_fails() {
 		assert_eq!(Teerex::enclave_count(), 1);
 
 		assert_err!(
-			Teerex::confirm_sidechainblock_proposed(
+			Teerex::confirm_proposed_sidechainblock(
 				Origin::signed(signer7.clone()),
 				shard4.clone(),
 				block_hash.clone(),

--- a/teerex/src/tests/tests.rs
+++ b/teerex/src/tests/tests.rs
@@ -252,7 +252,7 @@ fn update_ipfs_hash_works() {
 			URL.to_vec(),
 		));
 		assert_eq!(Teerex::enclave_count(), 1);
-		assert_ok!(Teerex::confirm_parentchainblock_processed(
+		assert_ok!(Teerex::confirm_processed_parentchainblock(
 			Origin::signed(signer.clone()),
 			shard.clone(),
 			block_hash.clone(),
@@ -261,7 +261,7 @@ fn update_ipfs_hash_works() {
 		assert_eq!(Teerex::worker_for_shard(shard.clone()), 1u64);
 
 		let expected_event =
-			Event::Teerex(RawEvent::ParentchainBlockProcessed(signer, block_hash, merkle_root));
+			Event::Teerex(RawEvent::ProcessedParentchainBlock(signer, block_hash, merkle_root));
 		assert!(System::events().iter().any(|a| a.event == expected_event));
 	})
 }
@@ -271,7 +271,7 @@ fn ipfs_update_from_unregistered_enclave_fails() {
 	new_test_ext().execute_with(|| {
 		let signer = get_signer(TEST4_SIGNER_PUB);
 		assert_err!(
-			Teerex::confirm_parentchainblock_processed(
+			Teerex::confirm_processed_parentchainblock(
 				Origin::signed(signer),
 				H256::default(),
 				H256::default(),
@@ -625,7 +625,7 @@ fn verify_unshield_funds_from_enclave_not_bonding_account_fails() {
 }
 
 #[test]
-fn confirm_confirm_parentchainblock_processed_works_for_correct_shard() {
+fn confirm_confirm_processed_parentchainblock_works_for_correct_shard() {
 	new_test_ext().execute_with(|| {
 		Timestamp::set_timestamp(TEST7_TIMESTAMP);
 		let block_hash = H256::default();
@@ -641,7 +641,7 @@ fn confirm_confirm_parentchainblock_processed_works_for_correct_shard() {
 		));
 		assert_eq!(Teerex::enclave_count(), 1);
 
-		assert_ok!(Teerex::confirm_parentchainblock_processed(
+		assert_ok!(Teerex::confirm_processed_parentchainblock(
 			Origin::signed(signer7.clone()),
 			shard7.clone(),
 			block_hash.clone(),
@@ -649,13 +649,13 @@ fn confirm_confirm_parentchainblock_processed_works_for_correct_shard() {
 		));
 
 		let expected_event =
-			Event::Teerex(RawEvent::ParentchainBlockProcessed(signer7, block_hash, merkle_root));
+			Event::Teerex(RawEvent::ProcessedParentchainBlock(signer7, block_hash, merkle_root));
 		assert!(System::events().iter().any(|a| a.event == expected_event));
 	})
 }
 
 #[test]
-fn verify_confirm_parentchainblock_processed_from_shards_neq_mrenclave_fails() {
+fn verify_confirm_processed_parentchainblock_from_shards_neq_mrenclave_fails() {
 	new_test_ext().execute_with(|| {
 		Timestamp::set_timestamp(TEST7_TIMESTAMP);
 		let block_hash = H256::default();
@@ -671,7 +671,7 @@ fn verify_confirm_parentchainblock_processed_from_shards_neq_mrenclave_fails() {
 		));
 
 		assert_err!(
-			Teerex::confirm_parentchainblock_processed(
+			Teerex::confirm_processed_parentchainblock(
 				Origin::signed(signer7),
 				shard4,
 				block_hash,

--- a/teerex/src/tests/tests.rs
+++ b/teerex/src/tests/tests.rs
@@ -547,7 +547,7 @@ fn verify_unshield_funds_works() {
 }
 
 #[test]
-fn verify_unshield_funds_from_not_registered_enclave_fails() {
+fn unshield_funds_from_not_registered_enclave_errs() {
 	new_test_ext().execute_with(|| {
 		Timestamp::set_timestamp(TEST4_TIMESTAMP);
 		let signer4 = get_signer(TEST4_SIGNER_PUB);
@@ -569,7 +569,7 @@ fn verify_unshield_funds_from_not_registered_enclave_fails() {
 }
 
 #[test]
-fn verify_unshield_funds_from_enclave_not_bonding_account_fails() {
+fn unshield_funds_from_enclave_neq_bonding_account_errs() {
 	new_test_ext().execute_with(|| {
 		Timestamp::set_timestamp(TEST7_TIMESTAMP);
 		let signer4 = get_signer(TEST4_SIGNER_PUB);
@@ -673,7 +673,7 @@ fn confirm_proposed_sidechainblock_works_for_correct_shard() {
 }
 
 #[test]
-fn verify_confirm_proposed_sidechainblock_from_shard_neq_mrenclave_fails() {
+fn confirm_proposed_sidechainblock_from_shard_neq_mrenclave_errs() {
 	new_test_ext().execute_with(|| {
 		Timestamp::set_timestamp(TEST7_TIMESTAMP);
 		let block_hash = H256::default();

--- a/teerex/src/tests/tests.rs
+++ b/teerex/src/tests/tests.rs
@@ -270,7 +270,7 @@ fn update_ipfs_hash_works() {
 		assert!(System::events().iter().any(|a| a.event == expected_event));
 
 		let expected_event =
-			Event::Teerex(RawEvent::ParentchainBlockProcessed(signer, merkle_root, request_hash));
+			Event::Teerex(RawEvent::ParentchainBlockProcessed(signer, block_hash, merkle_root));
 		assert!(System::events().iter().any(|a| a.event == expected_event));
 	})
 }

--- a/teerex/src/tests/tests.rs
+++ b/teerex/src/tests/tests.rs
@@ -619,7 +619,7 @@ fn verify_unshield_funds_from_enclave_not_bonding_account_fails() {
 }
 
 #[test]
-fn confirm_confirm_processed_parentchainblock_works() {
+fn confirm_processed_parentchainblock_works() {
 	new_test_ext().execute_with(|| {
 		Timestamp::set_timestamp(TEST7_TIMESTAMP);
 		let block_hash = H256::default();

--- a/teerex/src/weights.rs
+++ b/teerex/src/weights.rs
@@ -53,8 +53,8 @@ pub trait WeightInfo {
 	fn register_enclave() -> Weight;
 	fn unregister_enclave() -> Weight;
 	fn call_worker() -> Weight;
-	fn confirm_call() -> Weight;
-	fn confirm_block() -> Weight;
+	fn confirm_parentchainblock_processed() -> Weight;
+	fn confirm_sidechainblock_proposed() -> Weight;
 }
 
 /// Weights for pallet_teerex using the Integritee parachain node and recommended hardware.
@@ -73,12 +73,12 @@ impl<T: frame_system::Config> WeightInfo for IntegriteeWeight<T> {
 	fn call_worker() -> Weight {
 		(57_200_000 as Weight)
 	}
-	fn confirm_call() -> Weight {
+	fn confirm_parentchainblock_processed() -> Weight {
 		(46_900_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
-	fn confirm_block() -> Weight {
+	fn confirm_sidechainblock_proposed() -> Weight {
 		(46_200_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
@@ -100,12 +100,12 @@ impl WeightInfo for () {
 	fn call_worker() -> Weight {
 		(57_200_000 as Weight)
 	}
-	fn confirm_call() -> Weight {
+	fn confirm_parentchainblock_processed() -> Weight {
 		(46_900_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
 	}
-	fn confirm_block() -> Weight {
+	fn confirm_sidechainblock_proposed() -> Weight {
 		(46_200_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(2 as Weight))

--- a/teerex/src/weights.rs
+++ b/teerex/src/weights.rs
@@ -54,7 +54,7 @@ pub trait WeightInfo {
 	fn unregister_enclave() -> Weight;
 	fn call_worker() -> Weight;
 	fn confirm_parentchainblock_processed() -> Weight;
-	fn confirm_sidechainblock_proposed() -> Weight;
+	fn confirm_proposed_sidechainblock() -> Weight;
 }
 
 /// Weights for pallet_teerex using the Integritee parachain node and recommended hardware.
@@ -78,7 +78,7 @@ impl<T: frame_system::Config> WeightInfo for IntegriteeWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
-	fn confirm_sidechainblock_proposed() -> Weight {
+	fn confirm_proposed_sidechainblock() -> Weight {
 		(46_200_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
@@ -105,7 +105,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
 	}
-	fn confirm_sidechainblock_proposed() -> Weight {
+	fn confirm_proposed_sidechainblock() -> Weight {
 		(46_200_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(2 as Weight))

--- a/teerex/src/weights.rs
+++ b/teerex/src/weights.rs
@@ -53,7 +53,7 @@ pub trait WeightInfo {
 	fn register_enclave() -> Weight;
 	fn unregister_enclave() -> Weight;
 	fn call_worker() -> Weight;
-	fn confirm_parentchainblock_processed() -> Weight;
+	fn confirm_processed_parentchainblock() -> Weight;
 	fn confirm_proposed_sidechainblock() -> Weight;
 }
 
@@ -73,7 +73,7 @@ impl<T: frame_system::Config> WeightInfo for IntegriteeWeight<T> {
 	fn call_worker() -> Weight {
 		(57_200_000 as Weight)
 	}
-	fn confirm_parentchainblock_processed() -> Weight {
+	fn confirm_processed_parentchainblock() -> Weight {
 		(46_900_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
@@ -100,7 +100,7 @@ impl WeightInfo for () {
 	fn call_worker() -> Weight {
 		(57_200_000 as Weight)
 	}
-	fn confirm_parentchainblock_processed() -> Weight {
+	fn confirm_processed_parentchainblock() -> Weight {
 		(46_900_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(2 as Weight))


### PR DESCRIPTION
Related to issue https://github.com/integritee-network/worker/issues/457

Removes `CallConfirmation,` and splits `BlockConfirmation` in `SidechainblockProposed` and `ParentchainblockProcessed`

TODO:

- [x] remove `ipfs_hash` ( == `state_hash)` 
- [x] Merkle tree root: nothing done with it, except broadcasted in the associated event. That ok?