### PR TITLE
Add whitelist of trusted exchange rate oracles 

### DIFF
--- a/teeracle/Cargo.toml
+++ b/teeracle/Cargo.toml
@@ -103,6 +103,9 @@ git = "https://github.com/paritytech/substrate.git"
 branch = "master"
 version = "4.0.0-dev"
 
+[dev-dependencies.hex-literal]
+version = "0.3.2"
+
 [dependencies.teeracle-primitives]
 default-features = false
 package = "teeracle-primitives"

--- a/teeracle/src/benchmarking.rs
+++ b/teeracle/src/benchmarking.rs
@@ -66,7 +66,7 @@ benchmarks! {
 
 	}: _(RawOrigin::Root, mrenclave)
 	verify {
-		assert_eq!(Exchange::<T>::whitelisted_oracle_count(), 1, "mrenclave not added to whitelist")
+		assert_eq!(Exchange::<T>::whitelist().len(), 1, "mrenclave not added to whitelist")
 	}
 
 	remove_from_whitelist {
@@ -75,17 +75,7 @@ benchmarks! {
 
 	}: _(RawOrigin::Root, mrenclave)
 	verify {
-		assert_eq!(Exchange::<T>::whitelisted_oracle_count(), 0, "mrenclave not removed from whitelist")
-	}
-
-	clear_whitelist {
-		ensure_not_skipping_ra_check();
-		let mrenclave = TEST4_MRENCLAVE;
-		Exchange::<T>::add_to_whitelist(RawOrigin::Root.into(), mrenclave);
-
-	}: _(RawOrigin::Root)
-	verify {
-		assert_eq!(Exchange::<T>::whitelisted_oracle_count(), 0, "whitelist not cleared")
+		assert_eq!(Exchange::<T>::whitelist().len(), 0, "mrenclave not removed from whitelist")
 	}
 }
 

--- a/teeracle/src/benchmarking.rs
+++ b/teeracle/src/benchmarking.rs
@@ -53,7 +53,8 @@ benchmarks! {
 			TEST4_SETUP.cert.to_vec(),
 			URL.to_vec()
 		).unwrap();
-		Exchange::<T>::add_to_whitelist(RawOrigin::Root.into(), TEST4_MRENCLAVE);
+		let mrenclave = Teerex::<T>::enclave(1).mr_enclave;
+		Exchange::<T>::add_to_whitelist(RawOrigin::Root.into(), mrenclave);
 
 	}: _(RawOrigin::Signed(signer), currency, Some(rate))
 	verify {
@@ -70,7 +71,7 @@ benchmarks! {
 
 	remove_from_whitelist {
 		let mrenclave = TEST4_MRENCLAVE;
-		Exchange::<T>::add_to_whitelist(RawOrigin::Root.into(), TEST4_MRENCLAVE);
+		Exchange::<T>::add_to_whitelist(RawOrigin::Root.into(), mrenclave);
 
 	}: _(RawOrigin::Root, mrenclave)
 	verify {
@@ -78,8 +79,9 @@ benchmarks! {
 	}
 
 	clear_whitelist {
+		ensure_not_skipping_ra_check();
 		let mrenclave = TEST4_MRENCLAVE;
-		Exchange::<T>::add_to_whitelist(RawOrigin::Root.into(), TEST4_MRENCLAVE);
+		Exchange::<T>::add_to_whitelist(RawOrigin::Root.into(), mrenclave);
 
 	}: _(RawOrigin::Root)
 	verify {

--- a/teeracle/src/benchmarking.rs
+++ b/teeracle/src/benchmarking.rs
@@ -53,11 +53,37 @@ benchmarks! {
 			TEST4_SETUP.cert.to_vec(),
 			URL.to_vec()
 		).unwrap();
-
+		Exchange::<T>::add_to_whitelist(RawOrigin::Root.into(), TEST4_MRENCLAVE);
 
 	}: _(RawOrigin::Signed(signer), currency, Some(rate))
 	verify {
 		assert_eq!(Exchange::<T>::exchange_rate("usd".as_bytes().to_owned()), U32F32::from_num(43.65));
+	}
+
+	add_to_whitelist {
+		let mrenclave = TEST4_MRENCLAVE;
+
+	}: _(RawOrigin::Root, mrenclave)
+	verify {
+		assert_eq!(Exchange::<T>::whitelisted_oracle_count(), 1, "mrenclave not added to whitelist")
+	}
+
+	remove_from_whitelist {
+		let mrenclave = TEST4_MRENCLAVE;
+		Exchange::<T>::add_to_whitelist(RawOrigin::Root.into(), TEST4_MRENCLAVE);
+
+	}: _(RawOrigin::Root, mrenclave)
+	verify {
+		assert_eq!(Exchange::<T>::whitelisted_oracle_count(), 0, "mrenclave not removed from whitelist")
+	}
+
+	clear_whitelist {
+		let mrenclave = TEST4_MRENCLAVE;
+		Exchange::<T>::add_to_whitelist(RawOrigin::Root.into(), TEST4_MRENCLAVE);
+
+	}: _(RawOrigin::Root)
+	verify {
+		assert_eq!(Exchange::<T>::whitelisted_oracle_count(), 0, "whitelist not cleared")
 	}
 }
 

--- a/teeracle/src/lib.rs
+++ b/teeracle/src/lib.rs
@@ -87,6 +87,7 @@ pub mod pallet {
 		TooManyOracles,
 		NonWhitelistedOracle,
 		AlreadyWhitelistedOracle,
+		UntrustedOracle,
 	}
 
 	#[pallet::hooks]
@@ -129,6 +130,11 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			let sender = ensure_signed(origin)?;
 			<pallet_teerex::Module<T>>::is_registered_enclave(&sender)?;
+			let sender_index = <pallet_teerex::Module<T>>::enclave_index(sender);
+			ensure!(
+				Self::is_whitelisted(<pallet_teerex::Module<T>>::enclave(sender_index).mr_enclave),
+				<Error<T>>::UntrustedOracle
+			);
 			if new_value.is_none() || new_value == Some(U32F32::from_num(0)) {
 				log::info!("Delete exchange rate : {:?}", new_value);
 				ExchangeRates::<T>::mutate_exists(currency.clone(), |rate| *rate = None);

--- a/teeracle/src/lib.rs
+++ b/teeracle/src/lib.rs
@@ -31,7 +31,6 @@
 //!
 #![cfg_attr(not(feature = "std"), no_std)]
 pub use crate::weights::WeightInfo;
-use codec::Encode;
 pub use pallet::*;
 pub use substrate_fixed::types::U32F32;
 
@@ -107,9 +106,7 @@ pub mod pallet {
 		pub fn remove_from_whitelist(origin: OriginFor<T>, mrenclave: [u8; 32]) -> DispatchResult {
 			ensure_root(origin)?;
 			ensure!(Self::is_whitelisted(mrenclave), <Error<T>>::NonWhitelistedOracle);
-			Whitelist::<T>::mutate(|mrenclaves| {
-				mrenclaves.retain(|m| m.encode() != mrenclave.encode())
-			});
+			Whitelist::<T>::mutate(|mrenclaves| mrenclaves.retain(|m| *m != mrenclave));
 			Self::deposit_event(Event::RemovedFromWhitelist(mrenclave));
 			Ok(())
 		}
@@ -150,7 +147,7 @@ pub mod pallet {
 }
 impl<T: Config> Pallet<T> {
 	fn is_whitelisted(mrenclave: [u8; 32]) -> bool {
-		Self::whitelist().iter().any(|m| m.encode() == mrenclave.encode())
+		Self::whitelist().iter().any(|m| *m == mrenclave)
 	}
 
 	pub fn whitelisted_oracle_count() -> u32 {

--- a/teeracle/src/mock.rs
+++ b/teeracle/src/mock.rs
@@ -120,6 +120,7 @@ impl timestamp::Config for Test {
 parameter_types! {
 	pub const MomentsPerDay: u64 = 86_400_000; // [ms/d]
 	pub const MaxSilenceTime: u64 = 172_800_000; // 48h
+	pub const MaxOracles: u32 = 2;
 }
 
 impl pallet_teerex::Config for Test {
@@ -133,6 +134,7 @@ impl pallet_teerex::Config for Test {
 impl Config for Test {
 	type Event = Event;
 	type WeightInfo = ();
+	type MaxOracles = MaxOracles;
 }
 
 // This function basically just builds a genesis storage key/value store according to

--- a/teeracle/src/mock.rs
+++ b/teeracle/src/mock.rs
@@ -120,7 +120,7 @@ impl timestamp::Config for Test {
 parameter_types! {
 	pub const MomentsPerDay: u64 = 86_400_000; // [ms/d]
 	pub const MaxSilenceTime: u64 = 172_800_000; // 48h
-	pub const MaxOracles: u32 = 2;
+	pub const MaxWhitelistedReleases: u32 = 10;
 }
 
 impl pallet_teerex::Config for Test {
@@ -134,7 +134,7 @@ impl pallet_teerex::Config for Test {
 impl Config for Test {
 	type Event = Event;
 	type WeightInfo = ();
-	type MaxOracles = MaxOracles;
+	type MaxWhitelistedReleases = MaxWhitelistedReleases;
 }
 
 // This function basically just builds a genesis storage key/value store according to

--- a/teeracle/src/tests.rs
+++ b/teeracle/src/tests.rs
@@ -17,8 +17,12 @@
 use crate::{mock::*, ExchangeRates};
 use frame_support::{assert_err, assert_ok};
 use pallet_teerex::Error;
+use sp_runtime::DispatchError::BadOrigin;
 use substrate_fixed::types::U32F32;
-use test_utils::ias::consts::{TEST4_CERT, TEST4_SIGNER_PUB, TEST4_TIMESTAMP, URL};
+use test_utils::ias::consts::{
+	TEST4_CERT, TEST4_MRENCLAVE, TEST4_SIGNER_PUB, TEST4_TIMESTAMP, TEST5_MRENCLAVE,
+	TEST5_SIGNER_PUB, TEST8_MRENCLAVE, URL,
+};
 
 // give get_signer a concrete type
 fn get_signer(pubkey: &[u8; 32]) -> AccountId {
@@ -121,5 +125,122 @@ fn verifiy_update_exchange_rate_from_not_registered_enclave_fails() {
 			),
 			Error::<Test>::EnclaveIsNotRegistered
 		);
+	})
+}
+
+#[test]
+fn verifiy_add_to_whitelist_works() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Exchange::add_to_whitelist(Origin::root(), TEST4_MRENCLAVE));
+		let expected_event = Event::Exchange(crate::Event::AddedToWhitelist(TEST4_MRENCLAVE));
+		assert!(System::events().iter().any(|a| a.event == expected_event));
+		assert_eq!(Exchange::whitelisted_oracle_count(), 1);
+	})
+}
+
+#[test]
+fn verifiy_add_two_times_to_whitelist_fails() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Exchange::add_to_whitelist(Origin::root(), TEST4_MRENCLAVE));
+		assert_err!(
+			Exchange::add_to_whitelist(Origin::root(), TEST4_MRENCLAVE),
+			crate::Error::<Test>::AlreadyWhitelistedOracle
+		);
+		assert_eq!(Exchange::whitelisted_oracle_count(), 1);
+	})
+}
+
+#[test]
+fn verifiy_add_too_many_oracles_to_whitelist_fails() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Exchange::add_to_whitelist(Origin::root(), TEST4_MRENCLAVE));
+		assert_ok!(Exchange::add_to_whitelist(Origin::root(), TEST5_MRENCLAVE));
+		assert_err!(
+			Exchange::add_to_whitelist(Origin::root(), TEST8_MRENCLAVE),
+			crate::Error::<Test>::TooManyOracles
+		);
+		assert_eq!(Exchange::whitelisted_oracle_count(), 2);
+	})
+}
+
+#[test]
+fn verifiy_non_root_add_to_whitelist_fails() {
+	new_test_ext().execute_with(|| {
+		let signer = get_signer(TEST5_SIGNER_PUB);
+		assert_err!(Exchange::add_to_whitelist(Origin::signed(signer), TEST4_MRENCLAVE), BadOrigin);
+		assert_eq!(Exchange::whitelisted_oracle_count(), 0);
+	})
+}
+
+#[test]
+fn verifiy_remove_from_whitelist_works() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Exchange::add_to_whitelist(Origin::root(), TEST4_MRENCLAVE));
+		assert_ok!(Exchange::remove_from_whitelist(Origin::root(), TEST4_MRENCLAVE));
+		let expected_event = Event::Exchange(crate::Event::RemovedFromWhitelist(TEST4_MRENCLAVE));
+		assert!(System::events().iter().any(|a| a.event == expected_event));
+		assert_eq!(Exchange::whitelisted_oracle_count(), 0);
+	})
+}
+
+#[test]
+fn verifiy_remove_from_whitelist_not_whitelisted_fails() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Exchange::add_to_whitelist(Origin::root(), TEST4_MRENCLAVE));
+		assert_err!(
+			Exchange::remove_from_whitelist(Origin::root(), TEST5_MRENCLAVE),
+			crate::Error::<Test>::NonWhitelistedOracle
+		);
+		assert_eq!(Exchange::whitelisted_oracle_count(), 1);
+	})
+}
+
+#[test]
+fn verifiy_remove_from_empty_whitelist_doesnt_crash() {
+	new_test_ext().execute_with(|| {
+		assert_eq!(Exchange::whitelisted_oracle_count(), 0);
+		assert_err!(
+			Exchange::remove_from_whitelist(Origin::root(), TEST5_MRENCLAVE),
+			crate::Error::<Test>::NonWhitelistedOracle
+		);
+		assert_eq!(Exchange::whitelisted_oracle_count(), 0);
+	})
+}
+
+#[test]
+fn verifiy_non_root_remove_from_whitelist_fails() {
+	new_test_ext().execute_with(|| {
+		let signer = get_signer(TEST5_SIGNER_PUB);
+		assert_ok!(Exchange::add_to_whitelist(Origin::root(), TEST4_MRENCLAVE));
+		assert_err!(
+			Exchange::remove_from_whitelist(Origin::signed(signer), TEST4_MRENCLAVE),
+			BadOrigin
+		);
+		assert_eq!(Exchange::whitelisted_oracle_count(), 1);
+	})
+}
+
+#[test]
+fn verifiy_clear_whitelist_works() {
+	new_test_ext().execute_with(|| {
+		let signer = get_signer(TEST5_SIGNER_PUB);
+		assert_ok!(Exchange::add_to_whitelist(Origin::root(), TEST4_MRENCLAVE));
+		assert_ok!(Exchange::add_to_whitelist(Origin::root(), TEST5_MRENCLAVE));
+		assert_eq!(Exchange::whitelisted_oracle_count(), 2);
+
+		assert_ok!(Exchange::clear_whitelist(Origin::root()));
+		let expected_event = Event::Exchange(crate::Event::OracleWhitelistCleared);
+		assert!(System::events().iter().any(|a| a.event == expected_event));
+		assert_eq!(Exchange::whitelisted_oracle_count(), 0);
+	})
+}
+
+#[test]
+fn verifiy_non_root_clear_whitelist_fails() {
+	new_test_ext().execute_with(|| {
+		let signer = get_signer(TEST5_SIGNER_PUB);
+		assert_ok!(Exchange::add_to_whitelist(Origin::root(), TEST4_MRENCLAVE));
+		assert_err!(Exchange::clear_whitelist(Origin::signed(signer)), BadOrigin);
+		assert_eq!(Exchange::whitelisted_oracle_count(), 1);
 	})
 }

--- a/teeracle/src/tests.rs
+++ b/teeracle/src/tests.rs
@@ -37,7 +37,8 @@ fn register_enclave_and_add_oracle_to_whitelist_ok() {
 		TEST4_CERT.to_vec(),
 		URL.to_vec()
 	));
-	assert_ok!(Exchange::add_to_whitelist(Origin::root(), TEST4_MRENCLAVE));
+	let mrenclave = Teerex::enclave(1).mr_enclave;
+	assert_ok!(Exchange::add_to_whitelist(Origin::root(), mrenclave));
 }
 
 fn update_exchange_rate_for_dollars_ok(rate: Option<U32F32>) {

--- a/teeracle/src/tests.rs
+++ b/teeracle/src/tests.rs
@@ -51,7 +51,7 @@ fn update_exchange_rate_for_dollars_ok(rate: Option<U32F32>) {
 }
 
 #[test]
-fn verifiy_update_exchange_rate_works() {
+fn update_exchange_rate_works() {
 	new_test_ext().execute_with(|| {
 		register_enclave_and_add_oracle_to_whitelist_ok();
 
@@ -71,7 +71,7 @@ fn verifiy_update_exchange_rate_works() {
 }
 
 #[test]
-fn verifiy_get_existing_exchange_rate_works() {
+fn get_existing_exchange_rate_works() {
 	new_test_ext().execute_with(|| {
 		let rate = U32F32::from_num(43.65);
 		register_enclave_and_add_oracle_to_whitelist_ok();
@@ -81,7 +81,7 @@ fn verifiy_get_existing_exchange_rate_works() {
 }
 
 #[test]
-fn verifiy_get_inexisting_exchange_rate_is_zero() {
+fn get_inexisting_exchange_rate_is_zero() {
 	new_test_ext().execute_with(|| {
 		assert_eq!(ExchangeRates::<Test>::contains_key("eur".as_bytes().to_owned()), false);
 		assert_eq!(Exchange::exchange_rate("eur".as_bytes().to_owned()), U32F32::from_num(0));
@@ -89,7 +89,7 @@ fn verifiy_get_inexisting_exchange_rate_is_zero() {
 }
 
 #[test]
-fn verifiy_update_exchange_rate_to_none_delete_exchange_rate() {
+fn update_exchange_rate_to_none_delete_exchange_rate() {
 	new_test_ext().execute_with(|| {
 		register_enclave_and_add_oracle_to_whitelist_ok();
 		let rate = U32F32::from_num(43.65);
@@ -105,7 +105,7 @@ fn verifiy_update_exchange_rate_to_none_delete_exchange_rate() {
 }
 
 #[test]
-fn verifiy_update_exchange_rate_to_zero_delete_exchange_rate() {
+fn update_exchange_rate_to_zero_delete_exchange_rate() {
 	new_test_ext().execute_with(|| {
 		register_enclave_and_add_oracle_to_whitelist_ok();
 		let rate = Some(U32F32::from_num(43.65));
@@ -121,7 +121,7 @@ fn verifiy_update_exchange_rate_to_zero_delete_exchange_rate() {
 }
 
 #[test]
-fn verifiy_update_exchange_rate_from_not_registered_enclave_fails() {
+fn update_exchange_rate_from_not_registered_enclave_fails() {
 	new_test_ext().execute_with(|| {
 		let signer = get_signer(TEST4_SIGNER_PUB);
 		let rate = U32F32::from_num(43.65);
@@ -137,7 +137,7 @@ fn verifiy_update_exchange_rate_from_not_registered_enclave_fails() {
 }
 
 #[test]
-fn verifiy_update_exchange_rate_from_not_whitelisted_oracle_fails() {
+fn update_exchange_rate_from_not_whitelisted_oracle_fails() {
 	new_test_ext().execute_with(|| {
 		Timestamp::set_timestamp(TEST4_TIMESTAMP);
 		let signer = get_signer(TEST4_SIGNER_PUB);
@@ -160,7 +160,7 @@ fn verifiy_update_exchange_rate_from_not_whitelisted_oracle_fails() {
 }
 
 #[test]
-fn verifiy_add_to_whitelist_works() {
+fn add_to_whitelist_works() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Exchange::add_to_whitelist(Origin::root(), TEST4_MRENCLAVE));
 		let expected_event = Event::Exchange(crate::Event::AddedToWhitelist(TEST4_MRENCLAVE));
@@ -170,7 +170,7 @@ fn verifiy_add_to_whitelist_works() {
 }
 
 #[test]
-fn verifiy_add_two_times_to_whitelist_fails() {
+fn add_two_times_to_whitelist_fails() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Exchange::add_to_whitelist(Origin::root(), TEST4_MRENCLAVE));
 		assert_err!(
@@ -182,7 +182,7 @@ fn verifiy_add_two_times_to_whitelist_fails() {
 }
 
 #[test]
-fn verifiy_add_too_many_oracles_to_whitelist_fails() {
+fn add_too_many_oracles_to_whitelist_fails() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Exchange::add_to_whitelist(Origin::root(), TEST4_MRENCLAVE));
 		assert_ok!(Exchange::add_to_whitelist(Origin::root(), TEST5_MRENCLAVE));
@@ -195,7 +195,7 @@ fn verifiy_add_too_many_oracles_to_whitelist_fails() {
 }
 
 #[test]
-fn verifiy_non_root_add_to_whitelist_fails() {
+fn non_root_add_to_whitelist_fails() {
 	new_test_ext().execute_with(|| {
 		let signer = get_signer(TEST5_SIGNER_PUB);
 		assert_err!(Exchange::add_to_whitelist(Origin::signed(signer), TEST4_MRENCLAVE), BadOrigin);
@@ -204,7 +204,7 @@ fn verifiy_non_root_add_to_whitelist_fails() {
 }
 
 #[test]
-fn verifiy_remove_from_whitelist_works() {
+fn remove_from_whitelist_works() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Exchange::add_to_whitelist(Origin::root(), TEST4_MRENCLAVE));
 		assert_ok!(Exchange::remove_from_whitelist(Origin::root(), TEST4_MRENCLAVE));
@@ -215,7 +215,7 @@ fn verifiy_remove_from_whitelist_works() {
 }
 
 #[test]
-fn verifiy_remove_from_whitelist_not_whitelisted_fails() {
+fn remove_from_whitelist_not_whitelisted_fails() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Exchange::add_to_whitelist(Origin::root(), TEST4_MRENCLAVE));
 		assert_err!(
@@ -227,7 +227,7 @@ fn verifiy_remove_from_whitelist_not_whitelisted_fails() {
 }
 
 #[test]
-fn verifiy_remove_from_empty_whitelist_doesnt_crash() {
+fn remove_from_empty_whitelist_doesnt_crash() {
 	new_test_ext().execute_with(|| {
 		assert_eq!(Exchange::whitelisted_oracle_count(), 0);
 		assert_err!(
@@ -239,7 +239,7 @@ fn verifiy_remove_from_empty_whitelist_doesnt_crash() {
 }
 
 #[test]
-fn verifiy_non_root_remove_from_whitelist_fails() {
+fn non_root_remove_from_whitelist_fails() {
 	new_test_ext().execute_with(|| {
 		let signer = get_signer(TEST5_SIGNER_PUB);
 		assert_ok!(Exchange::add_to_whitelist(Origin::root(), TEST4_MRENCLAVE));
@@ -252,7 +252,7 @@ fn verifiy_non_root_remove_from_whitelist_fails() {
 }
 
 #[test]
-fn verifiy_clear_whitelist_works() {
+fn clear_whitelist_works() {
 	new_test_ext().execute_with(|| {
 		let signer = get_signer(TEST5_SIGNER_PUB);
 		assert_ok!(Exchange::add_to_whitelist(Origin::root(), TEST4_MRENCLAVE));
@@ -267,7 +267,7 @@ fn verifiy_clear_whitelist_works() {
 }
 
 #[test]
-fn verifiy_non_root_clear_whitelist_fails() {
+fn non_root_clear_whitelist_fails() {
 	new_test_ext().execute_with(|| {
 		let signer = get_signer(TEST5_SIGNER_PUB);
 		assert_ok!(Exchange::add_to_whitelist(Origin::root(), TEST4_MRENCLAVE));

--- a/teeracle/src/weights.rs
+++ b/teeracle/src/weights.rs
@@ -21,7 +21,6 @@ use sp_std::marker::PhantomData;
 pub trait WeightInfo {
 	fn add_to_whitelist() -> Weight;
 	fn remove_from_whitelist() -> Weight;
-	fn clear_whitelist() -> Weight;
 	fn update_exchange_rate() -> Weight;
 }
 
@@ -31,9 +30,6 @@ impl<T: frame_system::Config> WeightInfo for IntegriteeWeight<T> {
 		46_200_000 as Weight
 	}
 	fn remove_from_whitelist() -> Weight {
-		46_200_000 as Weight
-	}
-	fn clear_whitelist() -> Weight {
 		46_200_000 as Weight
 	}
 	fn update_exchange_rate() -> Weight {
@@ -46,9 +42,6 @@ impl WeightInfo for () {
 		46_200_000 as Weight
 	}
 	fn remove_from_whitelist() -> Weight {
-		46_200_000 as Weight
-	}
-	fn clear_whitelist() -> Weight {
 		46_200_000 as Weight
 	}
 	fn update_exchange_rate() -> Weight {

--- a/teeracle/src/weights.rs
+++ b/teeracle/src/weights.rs
@@ -19,17 +19,38 @@ use sp_std::marker::PhantomData;
 
 /// Weight functions needed for pallet_exchange.
 pub trait WeightInfo {
+	fn add_to_whitelist() -> Weight;
+	fn remove_from_whitelist() -> Weight;
+	fn clear_whitelist() -> Weight;
 	fn update_exchange_rate() -> Weight;
 }
 
 pub struct IntegriteeWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for IntegriteeWeight<T> {
+	fn add_to_whitelist() -> Weight {
+		46_200_000 as Weight
+	}
+	fn remove_from_whitelist() -> Weight {
+		46_200_000 as Weight
+	}
+	fn clear_whitelist() -> Weight {
+		46_200_000 as Weight
+	}
 	fn update_exchange_rate() -> Weight {
 		46_200_000 as Weight
 	}
 }
 // For tests
 impl WeightInfo for () {
+	fn add_to_whitelist() -> Weight {
+		46_200_000 as Weight
+	}
+	fn remove_from_whitelist() -> Weight {
+		46_200_000 as Weight
+	}
+	fn clear_whitelist() -> Weight {
+		46_200_000 as Weight
+	}
 	fn update_exchange_rate() -> Weight {
 		46_200_000 as Weight
 	}


### PR DESCRIPTION
Update of exchange rate can only be done by a trusted oracle