### PR TITLE
[sidechain-primitives] make no_std compatible + add full-crypto feature flag

### DIFF
--- a/primitives/sidechain/Cargo.toml
+++ b/primitives/sidechain/Cargo.toml
@@ -21,7 +21,10 @@ sp-std = { version = "4.0.0-dev", default-features = false, git = "https://githu
 
 
 [features]
-default = ["std"]
+default = ["std", "full_crypto"]
+full_crypto = [
+    "sp-core/full_crypto"
+]
 std = [
     "codec/std",
     "scale-info/std",

--- a/primitives/sidechain/src/traits/mod.rs
+++ b/primitives/sidechain/src/traits/mod.rs
@@ -21,14 +21,13 @@
 //! some generic structs.
 
 use codec::{Decode, Encode};
-use core::hash::Hash;
-use sp_core::{blake2_256, Public, H256};
-use sp_runtime::traits::Member;
+use sp_core::{crypto::Public, H256};
+use sp_runtime::traits::{BlakeTwo256, Hash, Member};
 use sp_std::{fmt::Debug, prelude::*};
 
 pub trait Header: Encode + Decode + Clone {
 	/// Identifier for the shards.
-	type ShardIdentifier: Encode + Decode + Hash + Copy + Member;
+	type ShardIdentifier: Encode + Decode + sp_std::hash::Hash + Copy + Member;
 
 	/// Get block number.
 	fn block_number(&self) -> u64;
@@ -41,7 +40,7 @@ pub trait Header: Encode + Decode + Clone {
 
 	/// get the `blake2_256` hash of the header.
 	fn hash(&self) -> H256 {
-		self.using_encoded(blake2_256).into()
+		self.using_encoded(BlakeTwo256::hash).into()
 	}
 
 	fn new(
@@ -68,7 +67,7 @@ pub trait BlockData: Encode + Decode + Send + Sync + Debug + Clone {
 	fn encrypted_state_diff(&self) -> &Vec<u8>;
 	/// get the `blake2_256` hash of the block
 	fn hash(&self) -> H256 {
-		self.using_encoded(blake2_256).into()
+		self.using_encoded(BlakeTwo256::hash).into()
 	}
 
 	fn new(

--- a/primitives/sidechain/src/types/header.rs
+++ b/primitives/sidechain/src/types/header.rs
@@ -16,7 +16,6 @@
 */
 
 //!Primitives for the sidechain
-#![cfg_attr(not(feature = "std"), no_std)]
 use crate::traits::Header as HeaderTrait;
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;

--- a/primitives/sidechain/src/types/header.rs
+++ b/primitives/sidechain/src/types/header.rs
@@ -20,7 +20,7 @@ use crate::traits::Header as HeaderTrait;
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_core::H256;
-use sp_io::hashing::blake2_256;
+use sp_runtime::traits::{BlakeTwo256, Hash};
 use sp_std::prelude::*;
 
 #[cfg(feature = "std")]
@@ -47,7 +47,7 @@ pub struct SidechainHeader {
 impl SidechainHeader {
 	/// get the `blake2_256` hash of the header.
 	pub fn hash(&self) -> H256 {
-		self.using_encoded(blake2_256).into()
+		self.using_encoded(BlakeTwo256::hash).into()
 	}
 }
 


### PR DESCRIPTION
So we do not have to import the massive crypto primitives into the parachain runtime