### PR TITLE
Update Cargo.toml files

### DIFF
--- a/parentchain/Cargo.toml
+++ b/parentchain/Cargo.toml
@@ -2,9 +2,9 @@
 name = "pallet-parentchain"
 description = "The remote attestation registry and verification pallet for integritee blockchains and parachains"
 version = "0.9.0"
-authors = ["Integritee AG"]
+authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
-repository = "https://github.com/integritee-network/pallet-teerex/"
+repository = "https://github.com/integritee-network/pallets/"
 license = "Apache-2.0"
 edition = "2021"
 

--- a/parentchain/test/Cargo.toml
+++ b/parentchain/test/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "parentchain-test"
 version = "0.8.0"
-authors = ["Integritee AG"]
+authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
+repository = "https://github.com/integritee-network/pallets/"
+license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]

--- a/primitives/claims/Cargo.toml
+++ b/primitives/claims/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "claims-primitives"
 version = "0.1.0"
-authors = ["Integritee AG"]
+authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
 repository = "https://github.com/integritee-network/pallets/"
 license = "Apache-2.0"

--- a/primitives/common/Cargo.toml
+++ b/primitives/common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "common-primitives"
 version = "0.1.0"
-authors = ["Integritee AG"]
+authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
 repository = "https://github.com/integritee-network/pallets/"
 license = "Apache-2.0"

--- a/primitives/sidechain/Cargo.toml
+++ b/primitives/sidechain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sidechain-primitives"
 version = "0.1.0"
-authors = ["Integritee AG"]
+authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
 repository = "https://github.com/integritee-network/pallets/"
 license = "Apache-2.0"

--- a/primitives/teeracle/Cargo.toml
+++ b/primitives/teeracle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "teeracle-primitives"
 version = "0.1.0"
-authors = ["Integritee AG"]
+authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
 repository = "https://github.com/integritee-network/pallets/"
 license = "Apache-2.0"

--- a/primitives/teerex/Cargo.toml
+++ b/primitives/teerex/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "teerex-primitives"
 version = "0.1.0"
-authors = ["Integritee AG"]
+authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
 repository = "https://github.com/integritee-network/pallets/"
 license = "Apache-2.0"

--- a/primitives/types/Cargo.toml
+++ b/primitives/types/Cargo.toml
@@ -2,7 +2,10 @@
 name = "itp-types"
 version = "0.8.0"
 authors = ["Integritee AG <hello@integritee.network>"]
-edition = "2018"
+homepage = "https://integritee.network/"
+repository = "https://github.com/integritee-network/pallets/"
+license = "Apache-2.0"
+edition = "2021"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }

--- a/primitives/utils/Cargo.toml
+++ b/primitives/utils/Cargo.toml
@@ -2,8 +2,10 @@
 name = "itp-utils"
 version = "0.8.0"
 authors = ["Integritee AG <hello@integritee.network>"]
-edition = "2018"
-
+homepage = "https://integritee.network/"
+repository = "https://github.com/integritee-network/pallets/"
+license = "Apache-2.0"
+edition = "2021"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }

--- a/sidechain/Cargo.toml
+++ b/sidechain/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pallet-sidechain"
 description = "Pallet for integritee sidechains"
 version = "0.9.0"
-authors = ["Integritee AG"]
+authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
 repository = "https://github.com/integritee-network/pallets/"
 license = "Apache-2.0"

--- a/sidechain/sidechain-block-verification/Cargo.toml
+++ b/sidechain/sidechain-block-verification/Cargo.toml
@@ -2,12 +2,11 @@
 name = "sidechain-block-verification"
 description = "Verification logic for sidechain blocks"
 version = "0.9.0"
-authors = ["Integritee AG"]
+authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
 repository = "https://github.com/integritee-network/pallets/"
 license = "Apache-2.0"
 edition = "2021"
-
 
 [dependencies]
 log = { version = "0.4.17", default-features = false }

--- a/sidechain/test/Cargo.toml
+++ b/sidechain/test/Cargo.toml
@@ -2,7 +2,10 @@
 name = "sidechain-test"
 version = "0.8.0"
 authors = ["Integritee AG <hello@integritee.network>"]
-edition = "2018"
+homepage = "https://integritee.network/"
+repository = "https://github.com/integritee-network/pallets/"
+license = "Apache-2.0"
+edition = "2021"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }

--- a/teeracle/Cargo.toml
+++ b/teeracle/Cargo.toml
@@ -2,9 +2,9 @@
 name = "pallet-teeracle"
 description = "A pallet to store cryptocurrency market data"
 version = "0.1.0"
-authors = ["Integritee AG"]
+authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
-repository = "https://github.com/integritee-network/pallets/teeracle/"
+repository = "https://github.com/integritee-network/pallets/"
 license = "Apache-2.0"
 edition = "2021"
 

--- a/teerex/Cargo.toml
+++ b/teerex/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pallet-teerex"
 description = "The remote attestation registry and verification pallet for integritee blockchains and parachains"
 version = "0.9.0"
-authors = ["Integritee AG"]
+authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
 repository = "https://github.com/integritee-network/pallets/"
 license = "Apache-2.0"

--- a/teerex/ias-verify/Cargo.toml
+++ b/teerex/ias-verify/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ias-verify"
 version = "0.1.4"
 description = "a certificate verification and IAS report parser crate for the teerex pallet"
-authors = ["Integritee AG"]
+authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
 repository = "https://github.com/integritee-network/pallets/"
 license = "Apache-2.0"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -2,9 +2,9 @@
 name = "test-utils"
 description = "A crate for common utilities for tests"
 version = "0.1.0"
-authors = ["Integritee AG"]
+authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
-repository = "https://github.com/integritee-network/pallets/tests-utils/"
+repository = "https://github.com/integritee-network/pallets/"
 license = "Apache-2.0"
 edition = "2021"
 


### PR DESCRIPTION
- Switch to edition 2021
- Standardize the fields license, authors, homepage, repository
- I would update the remaining repos in a similar way. 
- Note that there is the pallet-claims in this repo from parity which I did not change