### PR TITLE
Merge `develop` branch with updated polkadot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,12 @@ name: Build and Test
 on:
   push:
     branches:
-      - develop
       - master
       - 'sdk-v[0-9]+.[0-9]+.[0-9]+-*'
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
   pull_request:
     branches:
-      - develop
       - master
       - 'sdk-v[0-9]+.[0-9]+.[0-9]+-*'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,14 @@ name: Build and Test
 on:
   push:
     branches:
+      - develop
       - master
       - 'sdk-v[0-9]+.[0-9]+.[0-9]+-*'
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
   pull_request:
     branches:
+      - develop
       - master
       - 'sdk-v[0-9]+.[0-9]+.[0-9]+-*'
 

--- a/sidechain/src/benchmarking.rs
+++ b/sidechain/src/benchmarking.rs
@@ -53,8 +53,9 @@ benchmarks! {
 
 		let shard: ShardIdentifier = H256::from_slice(&TEST4_SETUP.mrenclave);
 		let hash: H256 = [2; 32].into();
+		let next_finalization_candidate_block_number = 1;
 
-	}: _(RawOrigin::Signed(accounts[0].clone()), shard, 1, hash)
+	}: _(RawOrigin::Signed(accounts[0].clone()), shard, 1, next_finalization_candidate_block_number, hash)
 	verify {
 		assert_latest_worker_update::<T>(&accounts[0], &shard)
 	}

--- a/sidechain/src/benchmarking.rs
+++ b/sidechain/src/benchmarking.rs
@@ -53,9 +53,9 @@ benchmarks! {
 
 		let shard: ShardIdentifier = H256::from_slice(&TEST4_SETUP.mrenclave);
 		let hash: H256 = [2; 32].into();
-		let next_finalization_candidate_block_number = 1;
-
-	}: _(RawOrigin::Signed(accounts[0].clone()), shard, 1, next_finalization_candidate_block_number, hash)
+		let block_number = 1;
+		let next_finalization_candidate_block_number = 20;
+	}: _(RawOrigin::Signed(accounts[0].clone()), shard, block_number, next_finalization_candidate_block_number, hash)
 	verify {
 		assert_latest_worker_update::<T>(&accounts[0], &shard)
 	}

--- a/sidechain/src/lib.rs
+++ b/sidechain/src/lib.rs
@@ -18,7 +18,7 @@ limitations under the License.
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::Encode;
-use frame_support::{dispatch::DispatchResultWithPostInfo, traits::Get};
+use frame_support::dispatch::DispatchResultWithPostInfo;
 use frame_system::{self};
 use pallet_teerex::Pallet as Teerex;
 use sidechain_primitives::SidechainBlockConfirmation;
@@ -52,9 +52,6 @@ pub mod pallet {
 	pub trait Config: frame_system::Config + pallet_teerex::Config {
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 		type WeightInfo: WeightInfo;
-		// If a block arrives far too early, an error should be returned
-		#[pallet::constant]
-		type EarlyBlockProposalLenience: Get<u64>;
 	}
 
 	#[pallet::event]
@@ -76,8 +73,9 @@ pub mod pallet {
 		StorageMap<_, Blake2_128Concat, ShardIdentifier, SidechainBlockConfirmation, ValueQuery>;
 
 	#[pallet::storage]
-	pub type SidechainBlockConfirmationQueue<T: Config> =
-		StorageMap<_, Blake2_128Concat, ShardBlockNumber, SidechainBlockConfirmation, ValueQuery>;
+	#[pallet::getter(fn sidechain_block_finalization_candidate)]
+	pub type SidechainBlockFinalizationCandidate<T: Config> =
+		StorageMap<_, Blake2_128Concat, ShardIdentifier, u64, ValueQuery>;
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
@@ -87,6 +85,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			shard_id: ShardIdentifier,
 			block_number: u64,
+			next_finalization_candidate_block_number: u64,
 			block_header_hash: H256,
 		) -> DispatchResultWithPostInfo {
 			let confirmation = SidechainBlockConfirmation { block_number, block_header_hash };
@@ -110,47 +109,29 @@ pub mod pallet {
 				return Ok(().into())
 			}
 
-			let lenience = T::EarlyBlockProposalLenience::get();
-			let mut latest_confirmation = <LatestSidechainBlockConfirmation<T>>::get(shard_id);
-			let latest_block_number = latest_confirmation.block_number;
 			let block_number = confirmation.block_number;
+			let finalization_candidate_block_number =
+				<SidechainBlockFinalizationCandidate<T>>::try_get(shard_id).unwrap_or(1);
 
-			if block_number > Self::add_to_block_number(latest_block_number, lenience)? {
-				// Block is far too early and hence refused.
-				return Err(<Error<T>>::BlockNumberTooHigh.into())
-			} else if block_number > Self::add_to_block_number(latest_block_number, 1)? {
-				// Block is too early and stored in the queue for later import.
-				if !<SidechainBlockConfirmationQueue<T>>::contains_key((shard_id, block_number)) {
-					<SidechainBlockConfirmationQueue<T>>::insert(
-						(shard_id, block_number),
-						confirmation,
-					);
-				}
-			} else if block_number == Self::add_to_block_number(latest_block_number, 1)? {
-				Self::finalize_block(shard_id, confirmation, &sender, sender_index);
-				latest_confirmation = confirmation;
+			ensure!(
+				block_number == finalization_candidate_block_number,
+				<Error<T>>::ReceivedUnexpectedSidechainBlock
+			);
 
-				Self::finalize_blocks_from_queue(
-					shard_id,
-					&sender,
-					sender_index,
-					latest_confirmation,
-				)?;
-			} else {
-				// Block is too late and hence refused.
-				return Err(<Error<T>>::OutdatedBlockNumber.into())
-			}
+			<SidechainBlockFinalizationCandidate<T>>::insert(
+				shard_id,
+				next_finalization_candidate_block_number,
+			);
 
+			Self::finalize_block(shard_id, confirmation, &sender, sender_index);
 			Ok(().into())
 		}
 	}
 
 	#[pallet::error]
 	pub enum Error<T> {
-		/// A proposed block is too early.
-		BlockNumberTooHigh,
-		/// A propsed block is too late and already outdated.
-		OutdatedBlockNumber,
+		/// A proposed block is unexpected.
+		ReceivedUnexpectedSidechainBlock,
 	}
 }
 
@@ -170,36 +151,6 @@ impl<T: Config> Pallet<T> {
 			block_header_hash
 		);
 		Self::deposit_event(Event::FinalizedSidechainBlock(sender.clone(), block_header_hash));
-	}
-
-	fn finalize_blocks_from_queue(
-		shard_id: ShardIdentifier,
-		sender: &T::AccountId,
-		sender_index: u64,
-		mut latest_confirmation: SidechainBlockConfirmation,
-	) -> DispatchResultWithPostInfo {
-		let mut latest_block_number = latest_confirmation.block_number;
-		let mut expected_block_number = Self::add_to_block_number(latest_block_number, 1)?;
-		let lenience = T::EarlyBlockProposalLenience::get();
-		let mut i: u64 = 0;
-		while <SidechainBlockConfirmationQueue<T>>::contains_key((shard_id, expected_block_number)) &&
-			i < lenience
-		{
-			let confirmation =
-				<SidechainBlockConfirmationQueue<T>>::take((shard_id, expected_block_number));
-
-			Self::finalize_block(shard_id, confirmation, sender, sender_index);
-			latest_confirmation = confirmation;
-
-			latest_block_number = latest_confirmation.block_number;
-			expected_block_number = Self::add_to_block_number(latest_block_number, 1)?;
-			i = Self::add_to_block_number(i, 1)?;
-		}
-		Ok(().into())
-	}
-
-	fn add_to_block_number(block_number: u64, diff: u64) -> Result<u64, &'static str> {
-		block_number.checked_add(diff).ok_or("[Sidechain]: Overflow adding new block")
 	}
 }
 

--- a/sidechain/src/lib.rs
+++ b/sidechain/src/lib.rs
@@ -117,6 +117,10 @@ pub mod pallet {
 				block_number == finalization_candidate_block_number,
 				<Error<T>>::ReceivedUnexpectedSidechainBlock
 			);
+			ensure!(
+				next_finalization_candidate_block_number > finalization_candidate_block_number,
+				<Error<T>>::InvalidNextFinalizationCandidateBlockNumber
+			);
 
 			<SidechainBlockFinalizationCandidate<T>>::insert(
 				shard_id,
@@ -132,6 +136,8 @@ pub mod pallet {
 	pub enum Error<T> {
 		/// A proposed block is unexpected.
 		ReceivedUnexpectedSidechainBlock,
+		/// The value for the next finalization candidate is invalid.
+		InvalidNextFinalizationCandidateBlockNumber,
 	}
 }
 

--- a/sidechain/src/mock.rs
+++ b/sidechain/src/mock.rs
@@ -132,18 +132,14 @@ impl pallet_teerex::Config for Test {
 	type MaxSilenceTime = MaxSilenceTime;
 }
 
-pub const EARLY_BLOCK_PROPOSAL_LENIENCE: u64 = 100;
-
 parameter_types! {
 	pub const MomentsPerDay: u64 = 86_400_000; // [ms/d]
 	pub const MaxSilenceTime: u64 = 172_800_000; // 48h
-	pub const EarlyBlockProposalLenience: u64 = EARLY_BLOCK_PROPOSAL_LENIENCE;
 }
 
 impl Config for Test {
 	type Event = Event;
 	type WeightInfo = ();
-	type EarlyBlockProposalLenience = EarlyBlockProposalLenience;
 }
 
 // This function basically just builds a genesis storage key/value store according to

--- a/sidechain/src/tests.rs
+++ b/sidechain/src/tests.rs
@@ -26,7 +26,7 @@ fn get_signer(pubkey: &[u8; 32]) -> AccountId {
 }
 
 #[test]
-fn confirm_imported_sidechain_block_works_for_correct_shard() {
+fn confirm_imported_sidechain_block_invalid_next_finalization_candidate() {
 	new_test_ext().execute_with(|| {
 		Timestamp::set_timestamp(TEST7_TIMESTAMP);
 		let hash = H256::default();
@@ -37,11 +37,37 @@ fn confirm_imported_sidechain_block_works_for_correct_shard() {
 
 		register_enclave7();
 
+		assert_err!(
+			Sidechain::confirm_imported_sidechain_block(
+				Origin::signed(signer7.clone()),
+				shard7,
+				block_number,
+				block_number,
+				hash
+			),
+			Error::<Test>::InvalidNextFinalizationCandidateBlockNumber,
+		);
+	})
+}
+
+#[test]
+fn confirm_imported_sidechain_block_works_for_correct_shard() {
+	new_test_ext().execute_with(|| {
+		Timestamp::set_timestamp(TEST7_TIMESTAMP);
+		let hash = H256::default();
+		let signer7 = get_signer(TEST7_SIGNER_PUB);
+		let shard7 = H256::from_slice(&TEST7_MRENCLAVE);
+
+		let block_number = 1;
+		let next_finalization_block_candidate = 20;
+
+		register_enclave7();
+
 		assert_ok!(Sidechain::confirm_imported_sidechain_block(
 			Origin::signed(signer7.clone()),
 			shard7,
 			block_number,
-			block_number,
+			next_finalization_block_candidate,
 			hash
 		));
 

--- a/teeracle/src/benchmarking.rs
+++ b/teeracle/src/benchmarking.rs
@@ -26,7 +26,6 @@ use frame_benchmarking::benchmarks;
 use frame_system::RawOrigin;
 use pallet_teerex::Pallet as Teerex;
 use sp_runtime::traits::CheckedConversion;
-use sp_std::borrow::ToOwned;
 use teeracle_primitives::{MarketDataSourceString, TradingPairString};
 use test_utils::{
 	get_signer,


### PR DESCRIPTION
This PR aims to get rid of the current `develop` branch, which was a temporary stand-in as the polkadot update (0.9.29) was blocked for a while in `worker`.