### PR TITLE
Updates to xcm-transactor-pallet to allow parachain to import successfully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,6 +2175,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "getrandom 0.2.8",
  "hex-literal",
  "log",
  "pallet-balances",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.36#a4e825c9500acab6cc3deccffea7b01350f12ed1"
+source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.36#afe528af891f464b318293f183f6d3eefbc979b0"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,7 +2175,6 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "getrandom 0.2.8",
  "hex-literal",
  "log",
  "pallet-balances",

--- a/primitives/xcm-transactor/src/lib.rs
+++ b/primitives/xcm-transactor/src/lib.rs
@@ -18,6 +18,7 @@
 use codec::{Decode, Encode, FullCodec};
 pub use cumulus_primitives_core::ParaId;
 use frame_support::RuntimeDebug;
+use sp_std::vec;
 use xcm::{latest::Weight as XcmWeight, prelude::*};
 
 pub trait BuildRelayCall {

--- a/xcm-transactor/Cargo.toml
+++ b/xcm-transactor/Cargo.toml
@@ -30,10 +30,6 @@ xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.3
 # cumulus
 cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.36", default-features = false }
 
-# benchmarking
-frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.36" }
-test-utils = { path = "../test-utils", optional = true, default-features = false }
-
 [dev-dependencies]
 externalities = { package = "sp-externalities", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.36" }
 frame-benchmarking = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.36" }
@@ -60,9 +56,6 @@ std = [
     "sp-std/std",
     "xcm/std",
 ]
-runtime-benchmarks = [
-    "frame-benchmarking",
-    "test-utils",
-]
+runtime-benchmarks = []
 
 try-runtime = ["frame-support/try-runtime"]

--- a/xcm-transactor/Cargo.toml
+++ b/xcm-transactor/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2021"
 codec = { version = "3.0.0", default-features = false, features = ["derive"], package = "parity-scale-codec" }
 log = { version = "0.4.14", default-features = false }
 scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
-getrandom = { version = "0.2", default-features = false, features = ["js"] }
 
 # Local
 xcm-transactor-primitives = { path = "../primitives/xcm-transactor", features = ["dot", "ksm"] }
@@ -56,7 +55,6 @@ std = [
     "sp-runtime/std",
     "sp-std/std",
     "xcm/std",
-    "getrandom/std",
 ]
 runtime-benchmarks = []
 

--- a/xcm-transactor/Cargo.toml
+++ b/xcm-transactor/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2021"
 codec = { version = "3.0.0", default-features = false, features = ["derive"], package = "parity-scale-codec" }
 log = { version = "0.4.14", default-features = false }
 scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
-getrandom = {version = "0.2", default-features = false, features = ["custom"]}
 
 # Local
 xcm-transactor-primitives = { path = "../primitives/xcm-transactor", features = ["dot", "ksm"] }
@@ -49,6 +48,7 @@ subxt = { git = "https://github.com/paritytech/subxt.git", branch = "master" }
 default = ["std"]
 std = [
     "codec/std",
+    "cumulus-primitives-core/std",
     "log/std",
     "scale-info/std",
     # substrate

--- a/xcm-transactor/Cargo.toml
+++ b/xcm-transactor/Cargo.toml
@@ -32,7 +32,6 @@ cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branc
 
 # benchmarking
 frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.36" }
-hex-literal = { version = "0.3.2", optional = true }
 test-utils = { path = "../test-utils", optional = true, default-features = false }
 
 [dev-dependencies]
@@ -61,7 +60,6 @@ std = [
 ]
 runtime-benchmarks = [
     "frame-benchmarking",
-    "hex-literal",
     "test-utils",
 ]
 

--- a/xcm-transactor/Cargo.toml
+++ b/xcm-transactor/Cargo.toml
@@ -58,6 +58,7 @@ std = [
     "sp-io/std",
     "sp-runtime/std",
     "sp-std/std",
+    "xcm/std",
 ]
 runtime-benchmarks = [
     "frame-benchmarking",

--- a/xcm-transactor/Cargo.toml
+++ b/xcm-transactor/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 codec = { version = "3.0.0", default-features = false, features = ["derive"], package = "parity-scale-codec" }
 log = { version = "0.4.14", default-features = false }
 scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
+getrandom = { version = "0.2", default-features = false, features = ["js"] }
 
 # Local
 xcm-transactor-primitives = { path = "../primitives/xcm-transactor", features = ["dot", "ksm"] }
@@ -55,6 +56,7 @@ std = [
     "sp-runtime/std",
     "sp-std/std",
     "xcm/std",
+    "getrandom/std",
 ]
 runtime-benchmarks = []
 

--- a/xcm-transactor/Cargo.toml
+++ b/xcm-transactor/Cargo.toml
@@ -14,7 +14,7 @@ log = { version = "0.4.14", default-features = false }
 scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
 
 # Local
-xcm-transactor-primitives = { path = "../primitives/xcm-transactor", features = ["dot", "ksm"] }
+xcm-transactor-primitives = { default-features = false, path = "../primitives/xcm-transactor", features = ["dot", "ksm"] }
 
 # substrate
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.36" }
@@ -55,6 +55,7 @@ std = [
     "sp-runtime/std",
     "sp-std/std",
     "xcm/std",
+    "xcm-transactor-primitives/std",
 ]
 runtime-benchmarks = []
 

--- a/xcm-transactor/Cargo.toml
+++ b/xcm-transactor/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 codec = { version = "3.0.0", default-features = false, features = ["derive"], package = "parity-scale-codec" }
 log = { version = "0.4.14", default-features = false }
 scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
+getrandom = {version = "0.2", default-features = false, features = ["custom"]}
 
 # Local
 xcm-transactor-primitives = { path = "../primitives/xcm-transactor", features = ["dot", "ksm"] }

--- a/xcm-transactor/src/lib.rs
+++ b/xcm-transactor/src/lib.rs
@@ -27,7 +27,7 @@ mod tests;
 #[frame_support::pallet]
 pub mod pallet {
 	use cumulus_primitives_core::ParaId;
-	use sp_std::vec;
+	use sp_std::vec::Vec;
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
 	use xcm::latest::{prelude::*, Weight as XcmWeight};

--- a/xcm-transactor/src/lib.rs
+++ b/xcm-transactor/src/lib.rs
@@ -27,9 +27,9 @@ mod tests;
 #[frame_support::pallet]
 pub mod pallet {
 	use cumulus_primitives_core::ParaId;
-	use sp_std::vec;
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
+	use sp_std::vec;
 	use xcm::latest::{prelude::*, Weight as XcmWeight};
 	use xcm_transactor_primitives::*;
 

--- a/xcm-transactor/src/lib.rs
+++ b/xcm-transactor/src/lib.rs
@@ -27,7 +27,7 @@ mod tests;
 #[frame_support::pallet]
 pub mod pallet {
 	use cumulus_primitives_core::ParaId;
-	use sp_std::vec::Vec;
+	use sp_std::vec;
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
 	use xcm::latest::{prelude::*, Weight as XcmWeight};

--- a/xcm-transactor/src/lib.rs
+++ b/xcm-transactor/src/lib.rs
@@ -27,6 +27,7 @@ mod tests;
 #[frame_support::pallet]
 pub mod pallet {
 	use cumulus_primitives_core::ParaId;
+	use sp_std::vec;
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
 	use xcm::latest::{prelude::*, Weight as XcmWeight};


### PR DESCRIPTION
My lesson to learn that the CI for the `pallets` repository does not catch issues when importing said pallet into a the parachain runtime. This fixes the issue of importing the xcm-transactor pallet.