### PR TITLE
Adding custom origin for xcm-transactor pallet

### DIFF
--- a/xcm-transactor/src/lib.rs
+++ b/xcm-transactor/src/lib.rs
@@ -46,6 +46,8 @@ pub mod pallet {
 
 		type XcmSender: SendXcm;
 
+		type SwapOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+
 		#[pallet::constant]
 		type ShellRuntimeParaId: Get<u32>;
 
@@ -83,7 +85,7 @@ pub mod pallet {
 			para_a: ParaId,
 			para_b: ParaId,
 		) -> DispatchResult {
-			ensure_root(origin)?;
+			T::SwapOrigin::ensure_origin(origin)?;
 			ensure!(para_a != para_b, Error::<T>::SwapIdsEqual);
 
 			let shell_id = ParaId::from(T::ShellRuntimeParaId::get());

--- a/xcm-transactor/src/mock.rs
+++ b/xcm-transactor/src/mock.rs
@@ -17,8 +17,8 @@
 
 use crate as pallet_xcm_transactor;
 use frame_support::parameter_types;
-use frame_system::EnsureRoot;
 use frame_system as system;
+use frame_system::EnsureRoot;
 use sp_core::H256;
 use sp_keyring::AccountKeyring;
 use sp_runtime::{

--- a/xcm-transactor/src/mock.rs
+++ b/xcm-transactor/src/mock.rs
@@ -17,6 +17,7 @@
 
 use crate as pallet_xcm_transactor;
 use frame_support::parameter_types;
+use frame_system::EnsureRoot;
 use frame_system as system;
 use sp_core::H256;
 use sp_keyring::AccountKeyring;
@@ -124,6 +125,7 @@ impl pallet_xcm_transactor::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RelayCallBuilder = RelayCallBuilder;
 	type XcmSender = DummySendXcm;
+	type SwapOrigin = EnsureRoot<AccountId>;
 	type ShellRuntimeParaId = ShellRuntimeParaId;
 	type IntegriteeKsmParaId = IntegriteeKsmParaId;
 	type WeightForParaSwap = WeightForParaSwap;


### PR DESCRIPTION
- Need to add custom origin for governance vote to suffice for making the `send_swap_ump()` call