### PR TITLE
Fix XCM Transact to be correct and add transactor to shell runtime

### DIFF
--- a/primitives/xcm-transactor/src/lib.rs
+++ b/primitives/xcm-transactor/src/lib.rs
@@ -19,8 +19,8 @@
 use codec::{Decode, Encode, FullCodec};
 pub use cumulus_primitives_core::ParaId;
 use frame_support::{
+	pallet_prelude::{Get, PhantomData},
 	RuntimeDebug,
-	pallet_prelude::{PhantomData, Get},
 };
 use sp_std::vec;
 use xcm::{latest::Weight as XcmWeight, prelude::*};
@@ -94,27 +94,22 @@ impl<Id: Get<ParaId>> BuildRelayCall for RelayCallBuilder<Id> {
 	}
 
 	fn construct_transact_xcm(call: Self::RelayCall, weight: XcmWeight) -> Xcm<()> {
-		let asset = MultiAsset {
-			id: Concrete(Here.into()),
-			fun: Fungibility::Fungible(500_000_000)
-		};
+		let asset =
+			MultiAsset { id: Concrete(Here.into()), fun: Fungibility::Fungible(500_000_000) };
 		Xcm(vec![
 			WithdrawAsset(asset.clone().into()),
-			BuyExecution {
-				fees: asset,
-				weight_limit: Unlimited
-			},
+			BuyExecution { fees: asset, weight_limit: Unlimited },
 			Transact {
 				origin_type: OriginKind::Native,
 				require_weight_at_most: weight,
-				call: call.encode().into()
+				call: call.encode().into(),
 			},
 			RefundSurplus,
 			DepositAsset {
 				assets: All.into(),
 				max_assets: 1,
-				beneficiary: X1(Parachain(Id::get().into())).into()
-			}
+				beneficiary: X1(Parachain(Id::get().into())).into(),
+			},
 		])
 	}
 }

--- a/primitives/xcm-transactor/src/lib.rs
+++ b/primitives/xcm-transactor/src/lib.rs
@@ -15,9 +15,13 @@
 
 */
 #![cfg_attr(not(feature = "std"), no_std)]
+
 use codec::{Decode, Encode, FullCodec};
 pub use cumulus_primitives_core::ParaId;
-use frame_support::RuntimeDebug;
+use frame_support::{
+	RuntimeDebug,
+	pallet_prelude::{PhantomData, Get},
+};
 use sp_std::vec;
 use xcm::{latest::Weight as XcmWeight, prelude::*};
 
@@ -81,8 +85,8 @@ pub use ksm::*;
 #[cfg(feature = "dot")]
 pub use dot::*;
 
-pub struct RelayCallBuilder;
-impl BuildRelayCall for RelayCallBuilder {
+pub struct RelayCallBuilder<Id>(PhantomData<Id>);
+impl<Id: Get<ParaId>> BuildRelayCall for RelayCallBuilder<Id> {
 	type RelayCall = RelayRuntimeCall;
 
 	fn swap_call(self_para_id: ParaId, other_para_id: ParaId) -> Self::RelayCall {
@@ -109,7 +113,7 @@ impl BuildRelayCall for RelayCallBuilder {
 			DepositAsset {
 				assets: All.into(),
 				max_assets: 1,
-				beneficiary: X1(Parachain(2015u32)).into()
+				beneficiary: X1(Parachain(Id::get().into())).into()
 			}
 		])
 	}

--- a/xcm-transactor/src/mock.rs
+++ b/xcm-transactor/src/mock.rs
@@ -123,7 +123,7 @@ impl SendXcm for DummySendXcm {
 
 impl pallet_xcm_transactor::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
-	type RelayCallBuilder = RelayCallBuilder;
+	type RelayCallBuilder = RelayCallBuilder<IntegriteeKsmParaId>;
 	type XcmSender = DummySendXcm;
 	type SwapOrigin = EnsureRoot<AccountId>;
 	type ShellRuntimeParaId = ShellRuntimeParaId;


### PR DESCRIPTION
- `construct_transact_xcm()` in xcm-transactor-primitives was incorrect
- Adding `paraId` generic param to `RelayCallBuilder` in xcm-transactor-primitives to support Refunding assets which would otherwise be trapped in the holding register
- Including pallet-xcm-transactor in the shellruntime