### PR TITLE
[xcm-transactor] expose xcm args in swap call

### DIFF
--- a/primitives/xcm-transactor/src/lib.rs
+++ b/primitives/xcm-transactor/src/lib.rs
@@ -43,11 +43,18 @@ pub trait BuildRelayCall {
 	/// - RelayCall (Different depending on Kusama or Polkadot)
 	/// - execution to be purchased via BuyExecution XCM Instruction
 	/// - Weight required to execute this call.
+	/// - Amount of execution to buy on the relay chain. This parameter is exposed because it varies
+	/// depending on the relay chain.
+	///
 	///
 	/// Returns:
 	/// - Corresponding XCM Message for Transacting on this RelayCall
 	///
-	fn construct_transact_xcm(call: Self::RelayCall, weight: XcmWeight) -> Xcm<()>;
+	fn construct_transact_xcm(
+		call: Self::RelayCall,
+		weight: XcmWeight,
+		buy_execution_fee: u128,
+	) -> Xcm<()>;
 }
 
 #[derive(Encode, Decode, RuntimeDebug)]
@@ -93,9 +100,13 @@ impl<Id: Get<ParaId>> BuildRelayCall for RelayCallBuilder<Id> {
 		Self::RelayCall::Registrar(RegistrarCall::Swap { this: self_para_id, other: other_para_id })
 	}
 
-	fn construct_transact_xcm(call: Self::RelayCall, weight: XcmWeight) -> Xcm<()> {
+	fn construct_transact_xcm(
+		call: Self::RelayCall,
+		weight: XcmWeight,
+		buy_execution_fee: u128,
+	) -> Xcm<()> {
 		let asset =
-			MultiAsset { id: Concrete(Here.into()), fun: Fungibility::Fungible(500_000_000) };
+			MultiAsset { id: Concrete(Here.into()), fun: Fungibility::Fungible(buy_execution_fee) };
 		Xcm(vec![
 			WithdrawAsset(asset.clone().into()),
 			BuyExecution { fees: asset, weight_limit: Unlimited },

--- a/primitives/xcm-transactor/src/lib.rs
+++ b/primitives/xcm-transactor/src/lib.rs
@@ -46,10 +46,8 @@ pub trait BuildRelayCall {
 	/// - Amount of execution to buy on the relay chain. This parameter is exposed because it varies
 	/// depending on the relay chain.
 	///
-	///
 	/// Returns:
 	/// - Corresponding XCM Message for Transacting on this RelayCall
-	///
 	fn construct_transact_xcm(
 		call: Self::RelayCall,
 		weight: XcmWeight,

--- a/xcm-transactor/src/lib.rs
+++ b/xcm-transactor/src/lib.rs
@@ -84,7 +84,7 @@ pub mod pallet {
 		///  Rococo-Local as of 11.01.2022:
 		///		* xcm_weight: 10_000_000_000
 		///		* buy_execution_weight: 500_000_000
-		///  Kusama: do be defined, but the weights will be higher than on Rococo-Local
+		///  Kusama: to be defined, but the weights will be higher than on Rococo-Local
 		///
 		#[pallet::call_index(0)]
 		#[pallet::weight(46_200_000)] // Arbitrary weight.

--- a/xcm-transactor/src/lib.rs
+++ b/xcm-transactor/src/lib.rs
@@ -82,7 +82,7 @@ pub mod pallet {
 		///
 		/// Sane weight values:
 		///  Rococo-Local as of 11.01.2022:
-		/// 	* xcm_weight: 10_000_000_000
+		///		* xcm_weight: 10_000_000_000
 		///		* buy_execution_weight: 500_000_000
 		///  Kusama: do be defined, but the weights will be higher than on Rococo-Local
 		///

--- a/xcm-transactor/src/lib.rs
+++ b/xcm-transactor/src/lib.rs
@@ -76,7 +76,6 @@ pub mod pallet {
 		/// This needs to be done from within a pallet as the `XCM` origin must be the parachain
 		/// itself.
 		///
-		///
 		/// This function should really only be called once via governance, on each chain that
 		/// performs the slot swap.
 		///

--- a/xcm-transactor/src/lib.rs
+++ b/xcm-transactor/src/lib.rs
@@ -54,16 +54,13 @@ pub mod pallet {
 		#[pallet::constant]
 		type IntegriteeKsmParaId: Get<u32>;
 
-		#[pallet::constant]
-		type WeightForParaSwap: Get<XcmWeight>;
-
 		type WeightInfo;
 	}
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
-		TransactSent { para_a: ParaId, para_b: ParaId },
+		SwapTransactSent { para_a: ParaId, para_b: ParaId },
 	}
 
 	#[pallet::error]
@@ -75,35 +72,37 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
-		// This function should really only be called once via governance
-		// There is chance for it to be called another time or two in the future
-		// This weight is ARBITRARY.
+		/// Send swap instruction to the relay chain to swap the slot lease of our two parachains.
+		/// This needs to be done from within a pallet as the `XCM` origin must be the parachain
+		/// itself.
+		///
+		///
+		/// This function should really only be called once via governance, on each chain that
+		/// performs the slot swap.
 		#[pallet::call_index(0)]
-		#[pallet::weight(46_200_000)]
+		#[pallet::weight(46_200_000)] // Arbitrary weight.
 		pub fn send_swap_ump(
 			origin: OriginFor<T>,
-			para_a: ParaId,
-			para_b: ParaId,
+			self_id: ParaId,
+			other_id: ParaId,
+			xcm_weight: XcmWeight,
+			buy_execution_fee: u128,
 		) -> DispatchResult {
 			T::SwapOrigin::ensure_origin(origin)?;
-			ensure!(para_a != para_b, Error::<T>::SwapIdsEqual);
+			ensure!(self_id != other_id, Error::<T>::SwapIdsEqual);
 
-			let shell_id = ParaId::from(T::ShellRuntimeParaId::get());
-			let integritee_id = ParaId::from(T::IntegriteeKsmParaId::get());
-			let input_valid = vec![para_a, para_b]
-				.iter()
-				.filter(|&&id| id == shell_id || id == integritee_id)
-				.count() == 2;
-			if !input_valid {
-				return Err(Error::<T>::InvalidSwapIds.into())
-			}
+			let valid_ids =
+				[T::ShellRuntimeParaId::get().into(), T::IntegriteeKsmParaId::get().into()];
 
-			let call = T::RelayCallBuilder::swap_call(para_a, para_b);
+			ensure!(valid_ids.contains(&self_id), Error::<T>::InvalidSwapIds);
+			ensure!(valid_ids.contains(&other_id), Error::<T>::InvalidSwapIds);
+
+			let call = T::RelayCallBuilder::swap_call(self_id, other_id);
 			let xcm_message =
-				T::RelayCallBuilder::construct_transact_xcm(call, T::WeightForParaSwap::get());
+				T::RelayCallBuilder::construct_transact_xcm(call, xcm_weight, buy_execution_fee);
 			T::XcmSender::send_xcm(Parent, xcm_message).map_err(|_| Error::<T>::TransactFailed)?;
 
-			Self::deposit_event(Event::<T>::TransactSent { para_a, para_b });
+			Self::deposit_event(Event::<T>::SwapTransactSent { para_a: self_id, para_b: other_id });
 			Ok(())
 		}
 	}

--- a/xcm-transactor/src/lib.rs
+++ b/xcm-transactor/src/lib.rs
@@ -79,6 +79,13 @@ pub mod pallet {
 		///
 		/// This function should really only be called once via governance, on each chain that
 		/// performs the slot swap.
+		///
+		/// Sane weight values:
+		///  Rococo-Local as of 11.01.2022:
+		/// 	* xcm_weight: 10_000_000_000
+		///		* buy_execution_weight: 500_000_000
+		///  Kusama: do be defined, but the weights will be higher than on Rococo-Local
+		///
 		#[pallet::call_index(0)]
 		#[pallet::weight(46_200_000)] // Arbitrary weight.
 		pub fn send_swap_ump(

--- a/xcm-transactor/src/mock.rs
+++ b/xcm-transactor/src/mock.rs
@@ -128,7 +128,6 @@ impl pallet_xcm_transactor::Config for Test {
 	type SwapOrigin = EnsureRoot<AccountId>;
 	type ShellRuntimeParaId = ShellRuntimeParaId;
 	type IntegriteeKsmParaId = IntegriteeKsmParaId;
-	type WeightForParaSwap = WeightForParaSwap;
 	type WeightInfo = ();
 }
 

--- a/xcm-transactor/src/mock.rs
+++ b/xcm-transactor/src/mock.rs
@@ -111,7 +111,6 @@ impl pallet_balances::Config for Test {
 parameter_types! {
 	pub const ShellRuntimeParaId: u32 = 2223u32;
 	pub const IntegriteeKsmParaId: u32 = 2015u32;
-	pub const WeightForParaSwap: XcmWeight = 10_000_000_000;
 }
 
 pub struct DummySendXcm;

--- a/xcm-transactor/src/tests.rs
+++ b/xcm-transactor/src/tests.rs
@@ -38,7 +38,9 @@ fn swap_ump_fails_not_privileged() {
 			XcmTransactor::send_swap_ump(
 				RuntimeOrigin::signed(alice),
 				ParaId::from(2015),
-				ParaId::from(2014)
+				ParaId::from(2014),
+				10_000_000_000,
+				10_000_000_000
 			),
 			sp_runtime::DispatchError::BadOrigin
 		);
@@ -52,7 +54,9 @@ fn swap_ump_fails_equal_para_ids() {
 			XcmTransactor::send_swap_ump(
 				RuntimeOrigin::root(),
 				ParaId::from(2015),
-				ParaId::from(2015)
+				ParaId::from(2015),
+				10_000_000_000,
+				10_000_000_000
 			),
 			Error::<Test>::SwapIdsEqual
 		);
@@ -67,7 +71,9 @@ fn swap_ump_fails_1_id_invalid() {
 			XcmTransactor::send_swap_ump(
 				RuntimeOrigin::root(),
 				shell_id.into(),
-				ParaId::from(20000)
+				ParaId::from(20000),
+				10_000_000_000,
+				10_000_000_000
 			),
 			Error::<Test>::InvalidSwapIds
 		);
@@ -82,7 +88,9 @@ fn swap_ump_fails_2_id_invalid() {
 			XcmTransactor::send_swap_ump(
 				RuntimeOrigin::root(),
 				integritee_id.into(),
-				ParaId::from(20000)
+				ParaId::from(20000),
+				10_000_000_000,
+				10_000_000_000
 			),
 			Error::<Test>::InvalidSwapIds
 		);
@@ -97,11 +105,13 @@ fn swap_ump_success() {
 		assert_ok!(XcmTransactor::send_swap_ump(
 			RuntimeOrigin::root(),
 			shell_id.into(),
-			integritee_id.into()
+			integritee_id.into(),
+			10_000_000_000,
+			10_000_000_000
 		));
 		assert!(System::events().iter().any(|swap| matches!(
 			swap.event,
-			RuntimeEvent::XcmTransactor(crate::Event::TransactSent { .. })
+			RuntimeEvent::XcmTransactor(crate::Event::SwapTransactSent { .. })
 		)));
 	})
 }


### PR DESCRIPTION
We had the issue that our xcm transact failed on the real Kusama chain because the xcm weights are different from the rococo-local setup. Hence, we should expose teh xcm values as args, so we don't run into the issue again that the call fails and there is nothing we can do without a runtime upgrade.

Tested that it works on a rococo local setup