### PR TITLE
Detect an underflow if the timestamp is zero

### DIFF
--- a/teerex/src/lib.rs
+++ b/teerex/src/lib.rs
@@ -453,7 +453,6 @@ impl<T: Config> Pallet<T> {
 		if minimum == 0 {
 			log::error!("Invalid time in unregister_silent_workers. Is the timestamp pallet properly configured?")
 		}
-		let minimum = (now - T::MaxSilenceTime::get()).saturated_into::<u64>();
 		let silent_workers = <EnclaveRegistry<T>>::iter()
 			.filter(|e| e.1.timestamp < minimum)
 			.map(|e| e.1.pubkey);

--- a/teerex/src/lib.rs
+++ b/teerex/src/lib.rs
@@ -25,7 +25,10 @@ use frame_support::{
 };
 use frame_system::{self, ensure_signed};
 use sp_core::H256;
-use sp_runtime::traits::{CheckedSub, SaturatedConversion};
+use sp_runtime::{
+	traits::{CheckedSub, SaturatedConversion},
+	Saturating,
+};
 use sp_std::{prelude::*, str};
 use teerex_primitives::*;
 
@@ -446,12 +449,10 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn unregister_silent_workers(now: T::Moment) {
-		let minimum = now
-			.checked_sub(&T::MaxSilenceTime::get())
-			.unwrap_or_default()
-			.saturated_into::<u64>();
+		let minimum = now.saturating_sub(T::MaxSilenceTime::get()).saturated_into::<u64>();
 		if minimum == 0 {
-			log::error!("Invalid time in unregister_silent_workers. Is the timestamp pallet properly configured?")
+			log::error!("Invalid time in unregister_silent_workers. Is the timestamp pallet properly configured?");
+			return
 		}
 		let silent_workers = <EnclaveRegistry<T>>::iter()
 			.filter(|e| e.1.timestamp < minimum)

--- a/teerex/src/lib.rs
+++ b/teerex/src/lib.rs
@@ -25,7 +25,7 @@ use frame_support::{
 };
 use frame_system::{self, ensure_signed};
 use sp_core::H256;
-use sp_runtime::traits::SaturatedConversion;
+use sp_runtime::traits::{CheckedSub, SaturatedConversion};
 use sp_std::{prelude::*, str};
 use teerex_primitives::*;
 
@@ -446,6 +446,13 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn unregister_silent_workers(now: T::Moment) {
+		let minimum = now
+			.checked_sub(&T::MaxSilenceTime::get())
+			.unwrap_or_default()
+			.saturated_into::<u64>();
+		if minimum == 0 {
+			log::error!("Invalid time in unregister_silent_workers. Is the timestamp pallet properly configured?")
+		}
 		let minimum = (now - T::MaxSilenceTime::get()).saturated_into::<u64>();
 		let silent_workers = <EnclaveRegistry<T>>::iter()
 			.filter(|e| e.1.timestamp < minimum)
@@ -568,8 +575,6 @@ impl<T: Config> Pallet<T> {
 
 	#[cfg(not(feature = "skip-ias-check"))]
 	fn ensure_timestamp_within_24_hours(report_timestamp: u64) -> DispatchResultWithPostInfo {
-		use sp_runtime::traits::CheckedSub;
-
 		let elapsed_time = <timestamp::Pallet<T>>::get()
 			.checked_sub(&T::Moment::saturated_from(report_timestamp))
 			.ok_or("Underflow while calculating elapsed time since report creation")?;

--- a/teerex/src/tests/test_cases.rs
+++ b/teerex/src/tests/test_cases.rs
@@ -160,7 +160,7 @@ fn add_and_remove_enclave_works() {
 }
 
 #[test]
-fn add_enclave_without_timestamp() {
+fn add_enclave_without_timestamp_fails() {
 	new_test_ext().execute_with(|| {
 		Timestamp::set_timestamp(0);
 		let signer = get_signer(TEST4_SIGNER_PUB);

--- a/teerex/src/tests/test_cases.rs
+++ b/teerex/src/tests/test_cases.rs
@@ -160,6 +160,21 @@ fn add_and_remove_enclave_works() {
 }
 
 #[test]
+fn add_enclave_without_timestamp() {
+	new_test_ext().execute_with(|| {
+		Timestamp::set_timestamp(0);
+		let signer = get_signer(TEST4_SIGNER_PUB);
+		assert!(Teerex::register_enclave(
+			RuntimeOrigin::signed(signer.clone()),
+			TEST4_CERT.to_vec(),
+			URL.to_vec(),
+		)
+		.is_err());
+		assert_eq!(Teerex::enclave_count(), 0);
+	})
+}
+
+#[test]
 fn list_enclaves_works() {
 	new_test_ext().execute_with(|| {
 		Timestamp::set_timestamp(TEST4_TIMESTAMP);


### PR DESCRIPTION
Currently there is an underflow if the timestamp is 0. I'm not quite sure how the timestamp-pallets works, but I think we should at least detect it.