### PR TITLE
Verify attributes of the quoting enclave 

### DIFF
--- a/primitives/teerex/src/lib.rs
+++ b/primitives/teerex/src/lib.rs
@@ -111,6 +111,16 @@ impl QuotingEnclave {
 			tcb,
 		}
 	}
+
+	pub fn attributes_flags_mask_as_u64(&self) -> u64 {
+		let slice_as_array: [u8; 8] = self.attributes_mask[0..8].try_into().unwrap();
+		u64::from_le_bytes(slice_as_array)
+	}
+
+	pub fn attributes_flags_as_u64(&self) -> u64 {
+		let slice_as_array: [u8; 8] = self.attributes[0..8].try_into().unwrap();
+		u64::from_le_bytes(slice_as_array)
+	}
 }
 
 #[derive(Encode, Decode, Default, Clone, PartialEq, Eq, sp_core::RuntimeDebug, TypeInfo)]

--- a/teerex/sgx-verify/src/lib.rs
+++ b/teerex/sgx-verify/src/lib.rs
@@ -298,10 +298,10 @@ impl SgxReportBody {
 		if self.isv_prod_id != o.isvprodid || self.mr_signer != o.mrsigner {
 			return false
 		}
-		if !self.verify_misc_select_field(&o) {
+		if !self.verify_misc_select_field(o) {
 			return false
 		}
-		if !self.verify_attributes_field(&o) {
+		if !self.verify_attributes_field(o) {
 			return false
 		}
 		for tcb in &o.tcb {

--- a/teerex/sgx-verify/src/lib.rs
+++ b/teerex/sgx-verify/src/lib.rs
@@ -274,16 +274,23 @@ impl SgxReportBody {
 		}
 	}
 
-	pub fn verify(&self, o: &QuotingEnclave) -> bool {
-		if self.isv_prod_id != o.isvprodid || self.mr_signer != o.mrsigner {
-			return false
-		}
+	fn verify_misc_select_field(&self, o: QuotingEnclave) -> bool {
 		for i in 0..self.misc_select.len() {
 			if (self.misc_select[i] & o.miscselect_mask[i]) !=
 				(o.miscselect[i] & o.miscselect_mask[i])
 			{
 				return false
 			}
+		}
+		true
+	}
+
+	pub fn verify(&self, o: &QuotingEnclave) -> bool {
+		if self.isv_prod_id != o.isvprodid || self.mr_signer != o.mrsigner {
+			return false
+		}
+		if !self.verify_misc_select_field(&o) {
+			return false
 		}
 		for tcb in &o.tcb {
 			// If the enclave isvsvn is bigger than one of the


### PR DESCRIPTION
The original issue was titled _Verify attributes and miscselectMask of the quoting enclave _, but the miscselect verification was already there, so I just added the attributes part.


Fixes #127