### PR TITLE
change license for teerex to MS-RSL

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+This license applies to the entire repo except for subfolders that have their own license file. In such cases, the license file in the subfolder takes precedence.
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/teerex/LICENSE
+++ b/teerex/LICENSE
@@ -1,0 +1,26 @@
+MICROSOFT REFERENCE SOURCE LICENSE (MS-RSL)
+
+This license governs use of the accompanying software. If you use the software, you accept this license. If you do not accept the license, do not use the software.
+
+1. Definitions
+The terms "reproduce," "reproduction" and "distribution" have the same meaning here as under U.S. copyright law.
+
+"You" means the licensee of the software.
+
+"Your company" means the company you worked for when you downloaded the software.
+
+"Reference use" means use of the software within your company as a reference, in read only form, for the sole purposes of debugging your products, maintaining your products, or enhancing the interoperability of your products with the software, and specifically excludes the right to distribute the software outside of your company.
+
+"Licensed patents" means any Licensor patent claims which read directly on the software as distributed by the Licensor under this license.
+
+2. Grant of Rights
+(A) Copyright Grant- Subject to the terms of this license, the Licensor grants you a non-transferable, non-exclusive, worldwide, royalty-free copyright license to reproduce the software for reference use.
+
+(B) Patent Grant- Subject to the terms of this license, the Licensor grants you a non-transferable, non-exclusive, worldwide, royalty-free patent license under licensed patents for reference use.
+
+3. Limitations
+(A) No Trademark License- This license does not grant you any rights to use the Licensor's name, logo, or trademarks.
+
+(B) If you begin patent litigation against the Licensor over patents that you think may apply to the software (including a cross-claim or counterclaim in a lawsuit), your license to the software ends automatically.
+
+(C) The software is licensed "as-is." You bear the risk of using it. The Licensor gives no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the Licensor excludes the implied warranties of merchantability, fitness for a particular purpose and non-infringement.

--- a/teerex/README.md
+++ b/teerex/README.md
@@ -1,5 +1,7 @@
 # pallet-teerex
 
+Please note this pallet has a different [license](./LICENSE) than the rest of this repository: MS-RSL
+
 A pallet for [Integritee](https://integritee.network) that acts as a verified registry for SGX enclaves. Its goal is to provide public auditability of remote attestation of SGX enclaves. Given deterministic builds of enclave code, this pallet closes the trust gap from source code to the MRENCLAVE of an enclave running on a genuine Intel SGX platfrom. Without the need for a license with Intel, everyone can verify what code is executed by registered service providers and that it is executed with confidentiality. A blockchain that integrates this pallet will, therefore, act as a public registry of remote attestated services.
 
 The pallet also acts as an indirect-invocation proxy for calls to the confidential state transition function executed in SGX enclaves off-chain.

--- a/teerex/sgx-verify/src/collateral.rs
+++ b/teerex/sgx-verify/src/collateral.rs
@@ -1,11 +1,11 @@
 /*
-	Copyright 2022 Integritee AG and Supercomputing Systems AG
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
 
-	Licensed under the Apache License, Version 2.0 (the "License");
+	Licensed under the MICROSOFT REFERENCE SOURCE LICENSE (MS-RSL) (the "License");
 	you may not use this file except in compliance with the License.
 	You may obtain a copy of the License at
 
-		http://www.apache.org/licenses/LICENSE-2.0
+		https://referencesource.microsoft.com/license.html
 
 	Unless required by applicable law or agreed to in writing, software
 	distributed under the License is distributed on an "AS IS" BASIS,

--- a/teerex/sgx-verify/src/ephemeral_key.rs
+++ b/teerex/sgx-verify/src/ephemeral_key.rs
@@ -1,3 +1,20 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the MICROSOFT REFERENCE SOURCE LICENSE (MS-RSL) (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		https://referencesource.microsoft.com/license.html
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
 use crate::{utils::length_from_raw_data, CertDer};
 use sp_std::convert::TryFrom;
 

--- a/teerex/sgx-verify/src/lib.rs
+++ b/teerex/sgx-verify/src/lib.rs
@@ -1,11 +1,11 @@
 /*
 	Copyright 2021 Integritee AG and Supercomputing Systems AG
 
-	Licensed under the Apache License, Version 2.0 (the "License");
+	Licensed under the MICROSOFT REFERENCE SOURCE LICENSE (MS-RSL) (the "License");
 	you may not use this file except in compliance with the License.
 	You may obtain a copy of the License at
 
-		http://www.apache.org/licenses/LICENSE-2.0
+		https://referencesource.microsoft.com/license.html
 
 	Unless required by applicable law or agreed to in writing, software
 	distributed under the License is distributed on an "AS IS" BASIS,

--- a/teerex/sgx-verify/src/netscape_comment.rs
+++ b/teerex/sgx-verify/src/netscape_comment.rs
@@ -1,3 +1,20 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the MICROSOFT REFERENCE SOURCE LICENSE (MS-RSL) (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		https://referencesource.microsoft.com/license.html
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
 use crate::{utils::length_from_raw_data, CertDer};
 use frame_support::ensure;
 use sp_std::{convert::TryFrom, prelude::Vec};

--- a/teerex/sgx-verify/src/tests.rs
+++ b/teerex/sgx-verify/src/tests.rs
@@ -1,3 +1,20 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the MICROSOFT REFERENCE SOURCE LICENSE (MS-RSL) (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		https://referencesource.microsoft.com/license.html
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
 use super::*;
 use crate::collateral::{EnclaveIdentitySigned, TcbInfoSigned};
 use codec::Decode;

--- a/teerex/sgx-verify/src/utils.rs
+++ b/teerex/sgx-verify/src/utils.rs
@@ -1,3 +1,20 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the MICROSOFT REFERENCE SOURCE LICENSE (MS-RSL) (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		https://referencesource.microsoft.com/license.html
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
 fn safe_indexing_one(data: &[u8], idx: usize) -> Result<usize, &'static str> {
 	let elt = data.get(idx).ok_or("Index out of bounds")?;
 	Ok(*elt as usize)

--- a/teerex/src/benchmarking.rs
+++ b/teerex/src/benchmarking.rs
@@ -15,7 +15,6 @@
 
 */
 
-
 //! Teerex pallet benchmarking
 
 #![cfg(any(test, feature = "runtime-benchmarks"))]

--- a/teerex/src/benchmarking.rs
+++ b/teerex/src/benchmarking.rs
@@ -1,11 +1,11 @@
 /*
 	Copyright 2021 Integritee AG and Supercomputing Systems AG
 
-	Licensed under the Apache License, Version 2.0 (the "License");
+	Licensed under the MICROSOFT REFERENCE SOURCE LICENSE (MS-RSL) (the "License");
 	you may not use this file except in compliance with the License.
 	You may obtain a copy of the License at
 
-		http://www.apache.org/licenses/LICENSE-2.0
+		https://referencesource.microsoft.com/license.html
 
 	Unless required by applicable law or agreed to in writing, software
 	distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,7 @@
 	limitations under the License.
 
 */
+
 
 //! Teerex pallet benchmarking
 

--- a/teerex/src/lib.rs
+++ b/teerex/src/lib.rs
@@ -1,11 +1,11 @@
 /*
 	Copyright 2021 Integritee AG and Supercomputing Systems AG
 
-	Licensed under the Apache License, Version 2.0 (the "License");
+	Licensed under the MICROSOFT REFERENCE SOURCE LICENSE (MS-RSL) (the "License");
 	you may not use this file except in compliance with the License.
 	You may obtain a copy of the License at
 
-		http://www.apache.org/licenses/LICENSE-2.0
+		https://referencesource.microsoft.com/license.html
 
 	Unless required by applicable law or agreed to in writing, software
 	distributed under the License is distributed on an "AS IS" BASIS,

--- a/teerex/src/mock.rs
+++ b/teerex/src/mock.rs
@@ -1,11 +1,11 @@
 /*
 	Copyright 2021 Integritee AG and Supercomputing Systems AG
 
-	Licensed under the Apache License, Version 2.0 (the "License");
+	Licensed under the MICROSOFT REFERENCE SOURCE LICENSE (MS-RSL) (the "License");
 	you may not use this file except in compliance with the License.
 	You may obtain a copy of the License at
 
-		http://www.apache.org/licenses/LICENSE-2.0
+		https://referencesource.microsoft.com/license.html
 
 	Unless required by applicable law or agreed to in writing, software
 	distributed under the License is distributed on an "AS IS" BASIS,

--- a/teerex/src/weights.rs
+++ b/teerex/src/weights.rs
@@ -1,11 +1,11 @@
 /*
 	Copyright 2021 Integritee AG and Supercomputing Systems AG
 
-	Licensed under the Apache License, Version 2.0 (the "License");
+	Licensed under the MICROSOFT REFERENCE SOURCE LICENSE (MS-RSL) (the "License");
 	you may not use this file except in compliance with the License.
 	You may obtain a copy of the License at
 
-		http://www.apache.org/licenses/LICENSE-2.0
+		https://referencesource.microsoft.com/license.html
 
 	Unless required by applicable law or agreed to in writing, software
 	distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
if this license actually prohibits forking our repo, we should extract teerex into its own repo. not sure TBH. but we can just go with this and change it if someone complains that forking is hereby prohibited

The basic goal is to be transparent, but protect integritee network from copycats on its basic value proposition (or DIY RA on other parachains)