### PR TITLE
gha: bump actions to remove Nodejs12 deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     name: Cancel Previous Runs
     runs-on: ubuntu-20.04
     steps:
-      - uses: styfle/cancel-workflow-action@0.4.1
+      - uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install cargo-about
-        uses: baptiste0928/cargo-install@v1
+        uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-about
           version: "0.5"


### PR DESCRIPTION
As seen in the [GitHub Actions run logs ](https://github.com/integritee-network/pallets/actions/runs/4972841445?pr=167) these two actions needed to be bumped.