### PR TITLE
[xcm-transactor] more expressive XCM error handling

### DIFF
--- a/xcm-transactor/src/lib.rs
+++ b/xcm-transactor/src/lib.rs
@@ -62,6 +62,7 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
+		SentXcm { hash: XcmHash },
 		SwapTransactSent { para_a: ParaId, para_b: ParaId },
 	}
 
@@ -141,14 +142,13 @@ pub mod pallet {
 			let xcm_message =
 				T::RelayCallBuilder::construct_transact_xcm(call, xcm_weight, buy_execution_fee);
 
-			// Todo: If we ever do this in the future again, we should also put the xcm-hash and
-			// the price in the deposited event.
-			let (_hash, _price) =
+			let (hash, _price) =
 				send_xcm::<T::XcmSender>(Parent.into(), xcm_message).map_err(|e| {
 					log::error!(target: LOG, "Error sending xcm: {:?}", e);
 					Error::<T>::from(e)
 				})?;
 
+			Self::deposit_event(Event::<T>::SentXcm { hash });
 			Self::deposit_event(Event::<T>::SwapTransactSent { para_a: self_id, para_b: other_id });
 			Ok(())
 		}

--- a/xcm-transactor/src/lib.rs
+++ b/xcm-transactor/src/lib.rs
@@ -24,7 +24,7 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
-const LOG: &'static str = "xcm-transactor";
+const LOG: &str = "xcm-transactor";
 
 #[frame_support::pallet]
 pub mod pallet {


### PR DESCRIPTION
* Closes #210 

Contains the commits that were deployed on the rococo runtime (https://github.com/integritee-network/parachain/pull/229) for debugging the slot swap UMP from https://github.com/integritee-network/pallets/tree/cl/more-expressive-xcm-error, but rebased on master