### PR TITLE
add proxied field to ias attestation_method too for attesteer rpc

### DIFF
--- a/primitives/teerex/src/lib.rs
+++ b/primitives/teerex/src/lib.rs
@@ -42,7 +42,7 @@ impl Default for SgxBuildMode {
 #[derive(Encode, Decode, Copy, Clone, PartialEq, Eq, sp_core::RuntimeDebug, TypeInfo)]
 pub enum SgxAttestationMethod {
 	Skip { proxied: bool },
-	Ias,
+	Ias { proxied: bool },
 	Dcap { proxied: bool },
 }
 
@@ -147,7 +147,8 @@ where
 			MultiEnclave::Sgx(enclave) => matches!(
 				enclave.attestation_method,
 				SgxAttestationMethod::Skip { proxied: true } |
-					SgxAttestationMethod::Dcap { proxied: true }
+					SgxAttestationMethod::Dcap { proxied: true } |
+					SgxAttestationMethod::Ias { proxied: true }
 			),
 		}
 	}
@@ -194,7 +195,7 @@ impl<Url> SgxEnclave<Url> {
 			Ok(p) => match self.attestation_method {
 				SgxAttestationMethod::Dcap { proxied: false } |
 				SgxAttestationMethod::Skip { proxied: false } |
-				SgxAttestationMethod::Ias => Some(p),
+				SgxAttestationMethod::Ias { proxied: false } => Some(p),
 				_ => None,
 			},
 			Err(_) => None,

--- a/sidechain/src/tests.rs
+++ b/sidechain/src/tests.rs
@@ -379,7 +379,7 @@ fn register_ias_enclave(signer_pub_key: &MrSigner, cert: &[u8]) {
 		RuntimeOrigin::signed(signer.clone()),
 		cert.to_vec(),
 		Some(URL.to_vec()),
-		SgxAttestationMethod::Ias,
+		SgxAttestationMethod::Ias { proxied: false },
 	));
 	assert!(Teerex::<Test>::sovereign_enclaves(signer).is_some());
 }

--- a/teeracle/src/benchmarking.rs
+++ b/teeracle/src/benchmarking.rs
@@ -49,7 +49,7 @@ benchmarks! {
 			RawOrigin::Signed(signer.clone()).into(),
 			TEST4_SETUP.cert.to_vec(),
 			Some(URL.to_vec()),
-			SgxAttestationMethod::Ias,
+			SgxAttestationMethod::Ias { proxied: false },
 		).unwrap();
 		let fingerprint = Teerex::<T>::sovereign_enclaves(&signer).unwrap().fingerprint();
 		Teeracle::<T>::add_to_whitelist(RawOrigin::Root.into(), data_source.clone(), fingerprint).unwrap();
@@ -72,7 +72,7 @@ benchmarks! {
 			RawOrigin::Signed(signer.clone()).into(),
 			TEST4_SETUP.cert.to_vec(),
 			Some(URL.to_vec()),
-			SgxAttestationMethod::Ias,
+			SgxAttestationMethod::Ias { proxied: false },
 		).unwrap();
 		let fingerprint = Teerex::<T>::sovereign_enclaves(&signer).unwrap().fingerprint();
 		Teeracle::<T>::add_to_whitelist(RawOrigin::Root.into(), data_source.clone(), fingerprint).unwrap();

--- a/teeracle/src/tests.rs
+++ b/teeracle/src/tests.rs
@@ -44,7 +44,7 @@ fn register_ias_enclave_and_add_oracle_to_whitelist_ok(src: &str) {
 		RuntimeOrigin::signed(signer.clone()),
 		TEST4_CERT.to_vec(),
 		Some(URL.to_vec()),
-		SgxAttestationMethod::Ias,
+		SgxAttestationMethod::Ias { proxied: false },
 	));
 	let fingerprint = Teerex::sovereign_enclaves(&signer).unwrap().fingerprint();
 	assert_ok!(Teeracle::add_to_whitelist(RuntimeOrigin::root(), src.to_owned(), fingerprint));
@@ -228,7 +228,7 @@ fn update_exchange_rate_from_not_whitelisted_oracle_fails() {
 			RuntimeOrigin::signed(signer.clone()),
 			TEST4_CERT.to_vec(),
 			Some(URL.to_vec()),
-			SgxAttestationMethod::Ias,
+			SgxAttestationMethod::Ias { proxied: false },
 		));
 
 		let rate = U32F32::from_num(43.65);
@@ -253,7 +253,7 @@ fn update_oracle_from_not_whitelisted_oracle_fails() {
 			RuntimeOrigin::signed(signer.clone()),
 			TEST4_CERT.to_vec(),
 			Some(URL.to_vec()),
-			SgxAttestationMethod::Ias,
+			SgxAttestationMethod::Ias { proxied: false },
 		));
 
 		assert_noop!(


### PR DESCRIPTION
closes #216 
this is a state breaking change. not sure when to merge

without this PR, IAS attestation through attesteer rpc will fail because the enclave signer isn't the sender of the registration extrinsic