### PR TITLE
add storage migration teerex V1->V2

### DIFF
--- a/teerex/src/lib.rs
+++ b/teerex/src/lib.rs
@@ -44,7 +44,7 @@ const SGX_RA_PROOF_MAX_LEN: usize = 5000;
 
 const MAX_URL_LEN: usize = 256;
 
-const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 
 #[frame_support::pallet]
 pub mod pallet {

--- a/teerex/src/migrations.rs
+++ b/teerex/src/migrations.rs
@@ -2,9 +2,6 @@ use super::*;
 
 use frame_support::{pallet_prelude::*, storage_alias, traits::OnRuntimeUpgrade};
 
-/// The log target.
-const TARGET: &str = "teerex::migration::v1";
-
 mod v0 {
 	use super::*;
 

--- a/teerex/src/migrations.rs
+++ b/teerex/src/migrations.rs
@@ -37,40 +37,50 @@ mod v0 {
 pub mod v1 {
 	use super::*;
 
+	#[derive(
+		Encode, Decode, Default, Copy, Clone, PartialEq, Eq, sp_core::RuntimeDebug, TypeInfo,
+	)]
+	pub struct SgxTcbInfoOnChainV1 {
+		pub issue_date: u64,
+		pub next_update: u64,
+	}
+
+	#[storage_alias]
+	pub type SgxTcbInfo<T: Config> =
+		StorageMap<Pallet<T>, Blake2_128Concat, Fmspc, SgxTcbInfoOnChainV1, OptionQuery>;
+
 	pub struct MigrateV0toV1<T>(sp_std::marker::PhantomData<T>);
 
 	impl<T: Config + frame_system::Config> OnRuntimeUpgrade for MigrateV0toV1<T> {
 		#[cfg(feature = "try-runtime")]
 		fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
-			let current_version = Pallet::<T>::current_storage_version();
 			let onchain_version = Pallet::<T>::on_chain_storage_version();
-			ensure!(onchain_version == 0 && current_version == 1, "only migration from v0 to v1");
 
 			let enclave_count = v0::EnclaveCount::<T>::get() as u64;
-			log::info!(target: TARGET, "{} enclaves will be purged", enclave_count,);
+			log::info!(
+				"teerexV1: {} v0 enclaves are present before eventual upgrade",
+				enclave_count,
+			);
 
 			let allow_debug_mode = v0::AllowSGXDebugMode::<T>::get();
-			log::info!(target: TARGET, "SGX debug mode was allowed: {}", allow_debug_mode);
-			Ok((enclave_count, allow_debug_mode).encode())
+			log::info!("teerexV1: SGX debug mode was allowed pre_upgrade: {}", allow_debug_mode);
+			Ok((onchain_version, enclave_count, allow_debug_mode).encode())
 		}
 
 		/// we simply purge the enclave registry as it renews within 24h anyway
 		fn on_runtime_upgrade() -> Weight {
-			let current_version = Pallet::<T>::current_storage_version();
+			let current_version = StorageVersion::new(1);
 			let onchain_version = Pallet::<T>::on_chain_storage_version();
 
 			log::info!(
-				target: TARGET,
-				"Running migration with current storage version {:?} / onchain {:?}",
+				"teerexV1: Running migration with current storage version {:?} / onchain {:?}",
 				current_version,
 				onchain_version
 			);
 
 			let mut purged_keys = 0u64;
 			if onchain_version >= current_version {
-				log::warn!(
-					target: TARGET,
-					"skipping on_runtime_upgrade: executed on wrong storage version."
+				log::warn!("teerexV1: skipping on_runtime_upgrade: executed on same or newer storage version."
 				);
 				return T::DbWeight::get().reads(1)
 			}
@@ -89,10 +99,18 @@ pub mod v1 {
 
 		#[cfg(feature = "try-runtime")]
 		fn post_upgrade(state: Vec<u8>) -> Result<(), &'static str> {
-			assert_eq!(Pallet::<T>::on_chain_storage_version(), 1, "must upgrade");
+			let (pre_onchain_version, _enclave_count, allow_debug_mode): (
+				StorageVersion,
+				u64,
+				bool,
+			) = Decode::decode(&mut &state[..]).expect("pre_upgrade provides a valid state; qed");
+			let post_onchain_version = Pallet::<T>::on_chain_storage_version();
+			if pre_onchain_version >= post_onchain_version {
+				log::info!("teerexV1: migration was skipped because onchain version was greater or equal to the target version of this migration step");
+				return Ok(())
+			}
 
-			let (_enclave_count, allow_debug_mode): (u64, bool) =
-				Decode::decode(&mut &state[..]).expect("pre_upgrade provides a valid state; qed");
+			assert_eq!(Pallet::<T>::on_chain_storage_version(), 1, "must upgrade");
 			let new_enclave_count = v0::EnclaveCount::<T>::get() as u64;
 			let new_allow_debug_mode = crate::SgxAllowDebugMode::<T>::get() as bool;
 
@@ -103,17 +121,73 @@ pub mod v1 {
 	}
 }
 
+pub mod v2 {
+	use super::*;
+
+	pub struct MigrateV1toV2<T>(sp_std::marker::PhantomData<T>);
+
+	impl<T: Config + frame_system::Config> OnRuntimeUpgrade for MigrateV1toV2<T> {
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
+			let current_version = Pallet::<T>::current_storage_version();
+			let onchain_version = Pallet::<T>::on_chain_storage_version();
+			ensure!(onchain_version == 1 && current_version == 2, "only migration from v1 to v2");
+
+			let tcb_info_count = v1::SgxTcbInfo::<T>::iter_keys().count() as u64;
+			log::info!("teerexV2: TCB info for {} fmspc entries will be purged", tcb_info_count);
+			Ok((tcb_info_count).encode())
+		}
+
+		/// we simply purge the enclave registry as it renews within 24h anyway
+		fn on_runtime_upgrade() -> Weight {
+			let current_version = Pallet::<T>::current_storage_version();
+			let onchain_version = Pallet::<T>::on_chain_storage_version();
+
+			log::info!(
+				"teerexV2: Running migration with current storage version {:?} / onchain {:?}",
+				current_version,
+				onchain_version
+			);
+
+			let mut purged_keys = 0u64;
+			if onchain_version >= current_version {
+				log::warn!(
+					"teerexV2: skipping on_runtime_upgrade: executed on wrong storage version."
+				);
+				return T::DbWeight::get().reads(1)
+			}
+
+			purged_keys += v1::SgxTcbInfo::<T>::clear(u32::MAX, None).unique as u64;
+
+			StorageVersion::new(2).put::<Pallet<T>>();
+			T::DbWeight::get().reads_writes(purged_keys + 1, purged_keys + 3)
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(state: Vec<u8>) -> Result<(), &'static str> {
+			assert_eq!(Pallet::<T>::on_chain_storage_version(), 2, "must upgrade");
+
+			let _: u64 =
+				Decode::decode(&mut &state[..]).expect("pre_upgrade provides a valid state; qed");
+			let new_tcb_info_count = v1::SgxTcbInfo::<T>::iter_keys().count() as u64;
+
+			assert_eq!(new_tcb_info_count, 0, "must purge all TCB info entries");
+			Ok(())
+		}
+	}
+}
+
 #[cfg(test)]
 #[cfg(feature = "try-runtime")]
 mod test {
 	use super::*;
-	use crate::migrations::v0::EnclaveV0;
-	use frame_support::traits::OnRuntimeUpgrade;
+	use crate::migrations::{v0::EnclaveV0, v1::SgxTcbInfoOnChainV1};
+	use frame_support::{assert_storage_noop, traits::OnRuntimeUpgrade};
 	use mock::{new_test_ext, Test as TestRuntime};
 
 	#[allow(deprecated)]
 	#[test]
-	fn migration_v0_to_v1_works() {
+	fn migration_v0_to_v2_works() {
 		new_test_ext().execute_with(|| {
 			StorageVersion::new(0).put::<Pallet<TestRuntime>>();
 
@@ -133,18 +207,69 @@ mod test {
 			v0::EnclaveCount::<TestRuntime>::put(1);
 			v0::AllowSGXDebugMode::<TestRuntime>::put(true);
 
-			// Migrate.
+			// Migrate V0 to V1.
 			let state = v1::MigrateV0toV1::<TestRuntime>::pre_upgrade().unwrap();
 			let _weight = v1::MigrateV0toV1::<TestRuntime>::on_runtime_upgrade();
 			v1::MigrateV0toV1::<TestRuntime>::post_upgrade(state).unwrap();
+			// Migrate V1 to V2
+			let state = v2::MigrateV1toV2::<TestRuntime>::pre_upgrade().unwrap();
+			let _weight = v2::MigrateV1toV2::<TestRuntime>::on_runtime_upgrade();
+			v2::MigrateV1toV2::<TestRuntime>::post_upgrade(state).unwrap();
 
 			// Check that all values got migrated.
-
 			assert_eq!(v0::EnclaveCount::<TestRuntime>::get(), 0);
 			assert_eq!(crate::SgxAllowDebugMode::<TestRuntime>::get(), true);
 			assert_eq!(v0::EnclaveRegistry::<TestRuntime>::iter_keys().count(), 0);
 			assert_eq!(v0::EnclaveIndex::<TestRuntime>::iter_keys().count(), 0);
 			assert_eq!(v0::AllowSGXDebugMode::<TestRuntime>::get(), false);
+		});
+	}
+
+	#[allow(deprecated)]
+	#[test]
+	fn migration_v1_to_v2_works() {
+		new_test_ext().execute_with(|| {
+			StorageVersion::new(1).put::<Pallet<TestRuntime>>();
+			assert_eq!(Pallet::<TestRuntime>::on_chain_storage_version(), 1);
+
+			// Insert some values into the v1 storage:
+			v1::SgxTcbInfo::<TestRuntime>::insert(Fmspc::default(), SgxTcbInfoOnChainV1::default());
+
+			// Migrate.
+			let state = v2::MigrateV1toV2::<TestRuntime>::pre_upgrade().unwrap();
+			let _weight = v2::MigrateV1toV2::<TestRuntime>::on_runtime_upgrade();
+			v2::MigrateV1toV2::<TestRuntime>::post_upgrade(state).unwrap();
+
+			// Check that all values got migrated.
+			assert_eq!(v1::SgxTcbInfo::<TestRuntime>::iter_keys().count(), 0);
+		});
+	}
+	#[allow(deprecated)]
+	#[test]
+	fn migration_v1_to_v1_is_noop() {
+		new_test_ext().execute_with(|| {
+			StorageVersion::new(1).put::<Pallet<TestRuntime>>();
+
+			// Insert some values into the v1 storage:
+			v1::SgxTcbInfo::<TestRuntime>::insert(Fmspc::default(), SgxTcbInfoOnChainV1::default());
+			// introduce outdated stuff that would be migrated if the migration would not be a noop
+			v0::EnclaveRegistry::<TestRuntime>::insert(
+				0,
+				EnclaveV0 {
+					pubkey: [0u8; 32].into(),
+					mr_enclave: MrEnclave::default(),
+					timestamp: 0,
+					url: "".into(),
+					sgx_mode: SgxBuildMode::default(),
+				},
+			);
+			v0::EnclaveIndex::<TestRuntime>::insert(AccountId::<TestRuntime>::from([0u8; 32]), 0);
+			v0::EnclaveCount::<TestRuntime>::put(1);
+			v0::AllowSGXDebugMode::<TestRuntime>::put(true);
+
+			let state = v1::MigrateV0toV1::<TestRuntime>::pre_upgrade().unwrap();
+			assert_storage_noop!(v1::MigrateV0toV1::<TestRuntime>::on_runtime_upgrade());
+			v1::MigrateV0toV1::<TestRuntime>::post_upgrade(state).unwrap();
 		});
 	}
 }

--- a/teerex/src/migrations.rs
+++ b/teerex/src/migrations.rs
@@ -60,7 +60,10 @@ pub mod v1 {
 			);
 
 			let allow_debug_mode = v0::AllowSGXDebugMode::<T>::get();
-			log::info!("teerexV1: SGX debug mode was allowed pre_upgrade: {}", allow_debug_mode);
+			log::info!(
+				"teerexV1: SGX debug mode (v0) was allowed pre_upgrade: {}",
+				allow_debug_mode
+			);
 			Ok((onchain_version, enclave_count, allow_debug_mode).encode())
 		}
 

--- a/teerex/src/migrations.rs
+++ b/teerex/src/migrations.rs
@@ -33,6 +33,8 @@ mod v0 {
 
 pub mod v1 {
 	use super::*;
+	/// The log target.
+	const TARGET: &str = "teerex::migration::v1";
 
 	#[derive(
 		Encode, Decode, Default, Copy, Clone, PartialEq, Eq, sp_core::RuntimeDebug, TypeInfo,
@@ -55,12 +57,14 @@ pub mod v1 {
 
 			let enclave_count = v0::EnclaveCount::<T>::get() as u64;
 			log::info!(
+				target: TARGET,
 				"teerexV1: {} v0 enclaves are present before eventual upgrade",
 				enclave_count,
 			);
 
 			let allow_debug_mode = v0::AllowSGXDebugMode::<T>::get();
 			log::info!(
+				target: TARGET,
 				"teerexV1: SGX debug mode (v0) was allowed pre_upgrade: {}",
 				allow_debug_mode
 			);
@@ -73,6 +77,7 @@ pub mod v1 {
 			let onchain_version = Pallet::<T>::on_chain_storage_version();
 
 			log::info!(
+				target: TARGET,
 				"teerexV1: Running migration with current storage version {:?} / onchain {:?}",
 				current_version,
 				onchain_version
@@ -80,7 +85,7 @@ pub mod v1 {
 
 			let mut purged_keys = 0u64;
 			if onchain_version >= current_version {
-				log::warn!("teerexV1: skipping on_runtime_upgrade: executed on same or newer storage version."
+				log::warn!(target: TARGET,"teerexV1: skipping on_runtime_upgrade: executed on same or newer storage version."
 				);
 				return T::DbWeight::get().reads(1)
 			}
@@ -106,7 +111,7 @@ pub mod v1 {
 			) = Decode::decode(&mut &state[..]).expect("pre_upgrade provides a valid state; qed");
 			let post_onchain_version = Pallet::<T>::on_chain_storage_version();
 			if pre_onchain_version >= post_onchain_version {
-				log::info!("teerexV1: migration was skipped because onchain version was greater or equal to the target version of this migration step");
+				log::info!(target: TARGET,"teerexV1: migration was skipped because onchain version was greater or equal to the target version of this migration step");
 				return Ok(())
 			}
 
@@ -123,6 +128,8 @@ pub mod v1 {
 
 pub mod v2 {
 	use super::*;
+	/// The log target.
+	const TARGET: &str = "teerex::migration::v2";
 
 	pub struct MigrateV1toV2<T>(sp_std::marker::PhantomData<T>);
 
@@ -134,7 +141,11 @@ pub mod v2 {
 			ensure!(onchain_version == 1 && current_version == 2, "only migration from v1 to v2");
 
 			let tcb_info_count = v1::SgxTcbInfo::<T>::iter_keys().count() as u64;
-			log::info!("teerexV2: TCB info for {} fmspc entries will be purged", tcb_info_count);
+			log::info!(
+				target: TARGET,
+				"teerexV2: TCB info for {} fmspc entries will be purged",
+				tcb_info_count
+			);
 			Ok((tcb_info_count).encode())
 		}
 
@@ -144,6 +155,7 @@ pub mod v2 {
 			let onchain_version = Pallet::<T>::on_chain_storage_version();
 
 			log::info!(
+				target: TARGET,
 				"teerexV2: Running migration with current storage version {:?} / onchain {:?}",
 				current_version,
 				onchain_version
@@ -152,6 +164,7 @@ pub mod v2 {
 			let mut purged_keys = 0u64;
 			if onchain_version >= current_version {
 				log::warn!(
+					target: TARGET,
 					"teerexV2: skipping on_runtime_upgrade: executed on wrong storage version."
 				);
 				return T::DbWeight::get().reads(1)


### PR DESCRIPTION
tested against rococo and kusama:

```
./target/release/integritee-collator try-runtime   --chain integritee-rococo   --runtime ./target/release/wbuild/integritee-runtime/integritee_runtime.wasm   on-runtime-upgrade --checks=all   live --uri wss://rococo.api.integritee.network:443
2023-09-15 13:54:01 replacing wss:// in uri with https://: "https://rococo.api.integritee.network:443" (ws is currently unstable for fetching remote storage, for more see https://github.com/paritytech/jsonrpsee/issues/1086)    
2023-09-15 13:54:01 since no at is provided, setting it to latest finalized head, 0xb495449e0d711cc5f03524f956b6c81c3fdb57936894899715f81c5584d156fd    
2023-09-15 13:54:01 since no prefix is filtered, the data for all pallets will be downloaded    
2023-09-15 13:54:01 scraping key-pairs from remote at block height 0xb495449e0d711cc5f03524f956b6c81c3fdb57936894899715f81c5584d156fd    
2023-09-15 13:54:02 Querying a total of 2347 keys from prefix , splitting among 4 threads, 587 keys per thread    
2023-09-15 13:54:02 inserting keys progress = 25% [586 / 2347]    
2023-09-15 13:54:03 inserting keys progress = 50% [1173 / 2347]    
2023-09-15 13:54:03 inserting keys progress = 75% [1760 / 2347]    
2023-09-15 13:54:03 inserting keys progress = 100% [2347 / 2347]    
2023-09-15 13:54:03 adding data for hashed prefix: , took 1s    
2023-09-15 13:54:03 adding data for hashed key: 3a636f6465    
2023-09-15 13:54:03 adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef7f9cce9c888469bb1a0dceaa129672ef8    
2023-09-15 13:54:03 adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac    
2023-09-15 13:54:03 initialized state externalities with storage root 0xd50b2839677f9363192c4079ea5b57e87bc33cfbd4c9bcfca45a8028273dba57 and state_version V0    
2023-09-15 13:54:03 original spec: RuntimeString::Owned("integritee-parachain")-37, code hash: 91b3dad54a4ddb857dfd7932d1ceeac5ed8d90b965368843017f14f60e9bf278    
2023-09-15 13:54:03 new spec: RuntimeString::Owned("integritee-parachain")-38, code hash: 692fcb49b812a1b0019dfd7a023fa777de6b7365a52b886215380f5bb153eae5    
2023-09-15 13:54:04 teerexV1: 0 v0 enclaves are present before eventual upgrade    
2023-09-15 13:54:04 teerexV1: SGX debug mode was allowed pre_upgrade: false    
2023-09-15 13:54:04 teerexV1: Running migration with current storage version StorageVersion(1) / onchain StorageVersion(1)    
2023-09-15 13:54:04 teerexV1: skipping on_runtime_upgrade: executed on same or newer storage version.    
2023-09-15 13:54:04 teerexV1: migration was skipped because onchain version was greater or equal to the target version of this migration step    
2023-09-15 13:54:04 teerexV2: TCB info for 3 fmspc entries will be purged    
2023-09-15 13:54:04 teerexV2: Running migration with current storage version StorageVersion(2) / onchain StorageVersion(1)    
2023-09-15 13:54:04 ⚠️ ParachainSystem declares internal migrations (which *might* execute). On-chain `StorageVersion(2)` vs current storage version `StorageVersion(2)`    
2023-09-15 13:54:04 ⚠️ XcmpQueue declares internal migrations (which *might* execute). On-chain `StorageVersion(3)` vs current storage version `StorageVersion(2)`    
2023-09-15 13:54:04 ⚠️ PolkadotXcm declares internal migrations (which *might* execute). On-chain `StorageVersion(0)` vs current storage version `StorageVersion(1)`    
2023-09-15 13:54:04 ⚠️ DmpQueue declares internal migrations (which *might* execute). On-chain `StorageVersion(2)` vs current storage version `StorageVersion(1)`    
2023-09-15 13:54:04 TryRuntime_on_runtime_upgrade executed without errors. Consumed weight = (925000000 ps, 0 byte), total weight = (500000000000 ps, 5242880 byte) (0.18 %, 0.00 %).  
```