### PR TITLE
cleanup workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -924,7 +924,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
@@ -958,7 +958,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -976,7 +976,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -988,7 +988,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -998,7 +998,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "cfg-if",
  "frame-support",
@@ -1823,7 +1823,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1992,7 +1992,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2010,7 +2010,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2850,7 +2850,7 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "hash-db",
  "log",
@@ -2871,7 +2871,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "Inflector",
  "blake2",
@@ -2885,7 +2885,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -2912,7 +2912,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2925,7 +2925,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2937,7 +2937,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -2982,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -2995,7 +2995,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "quote",
  "sp-core-hashing",
@@ -3005,7 +3005,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3015,7 +3015,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -3026,7 +3026,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -3040,7 +3040,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "bytes",
  "ed25519",
@@ -3065,7 +3065,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -3076,7 +3076,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.27.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
@@ -3088,7 +3088,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -3099,7 +3099,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -3109,7 +3109,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -3131,7 +3131,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -3149,7 +3149,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -3161,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -3175,7 +3175,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.28.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "hash-db",
  "log",
@@ -3196,12 +3196,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 
 [[package]]
 name = "sp-storage"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -3214,7 +3214,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -3227,7 +3227,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -3239,7 +3239,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "ahash 0.8.6",
  "hash-db",
@@ -3262,7 +3262,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -3279,7 +3279,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -3290,7 +3290,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ chrono = { version = "0.4", default-features = false, features = ["serde"] }
 derive_more = "0.99.16"
 env_logger = "0.9.0"
 hex = { default-features = false, version = "0.4.3", features = ["alloc"] }
-hex-literal = "0.3.2"
+hex-literal = "0.3.3"
 log = { version = "0.4.14", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
-serde = { version = "1.0.171", features = ["derive"] }
+serde = { version = "1.0.171", features = ["alloc", "derive"] }
 serde_derive = { version = "1.0.171" }
 serde_json = { version = "1.0" }
 
@@ -39,7 +39,7 @@ webpki = { git = "https://github.com/rustls/webpki", version = "=0.102.0-alpha.3
 x509-cert = { default-features = false, version = "0.1.0", features = ["alloc"] }
 
 # polkadot-sdk and ecosystem crates [no_std]
-cumulus-primitives-core = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+cumulus-primitives-core = { default-features = false, git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v1.0.0" }
 frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
@@ -53,7 +53,7 @@ sp-io = { default-features = false, git = "https://github.com/paritytech/substra
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 substrate-fixed = { tag = "v0.5.9", default-features = false, git = "https://github.com/encointer/substrate-fixed.git" }
-xcm = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
+xcm = { default-features = false, git = "https://github.com/paritytech/polkadot.git", branch = "release-v1.0.0" }
 
 # dev-deps [std]
 sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ hex = { default-features = false, version = "0.4.3", features = ["alloc"] }
 hex-literal = "0.3.3"
 log = { version = "0.4.14", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
-serde = { version = "1.0.171", features = ["alloc", "derive"] }
+serde = { version = "1.0.171", default-features = false, features = ["alloc", "derive"] }
 serde_derive = { version = "1.0.171" }
 serde_json = { version = "1.0" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,41 @@ members = [
     "primitives/common",
     "primitives/xcm-transactor",
 ]
+
+[workspace.dependencies]
+base64 = { version = "0.13", default-features = false, features = ["alloc"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
+parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+cumulus-primitives-core = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+der = { default-features = false, version = "0.6.0" }
+env_logger = "0.9.0"
+externalities = { package = "sp-externalities", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+hex = { default-features = false, version = "0.4.3", features = ["alloc"] }
+hex-literal = "0.3.2"
+libsecp256k1 = { version = "0.7.0", default-features = false }
+log = { version = "0.4.14", default-features = false }
+pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+pallet-timestamp = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+pallet-vesting = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+ring = { version = "0.16.20", default-features = false, features = ["alloc"] }
+rustc-hex = { version = "2.1.0", default-features = false }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+serde = { version = "1.0.171", features = ["derive"] }
+serde_derive = { version = "1.0.171" }
+serde_json = { version = "1.0" }
+sgx-verify = { path = "sgx-verify", default-features = false }
+sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+substrate-fixed = { tag = "v0.5.9", default-features = false, git = "https://github.com/encointer/substrate-fixed.git" }
+teerex-primitives = { path = "../primitives/teerex", default-features = false }
+timestamp = { package = "pallet-timestamp", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+webpki = { git = "https://github.com/rustls/webpki", version = "=0.102.0-alpha.3", rev = "da923ed", package = "rustls-webpki", default-features = false, features = ["alloc", "ring"] }
+x509-cert = { default-features = false, version = "0.1.0", features = ["alloc"] }
+xcm = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
+derive_more = "0.99.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ libsecp256k1 = { version = "0.7.0", default-features = false }
 log = { version = "0.4.14", default-features = false }
 pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 pallet-timestamp = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-vesting = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+pallet-vesting = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 ring = { version = "0.16.20", default-features = false, features = ["alloc"] }
 rustc-hex = { version = "2.1.0", default-features = false }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ log = { version = "0.4.14", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
 serde = { version = "1.0.171", default-features = false, features = ["alloc", "derive"] }
 serde_derive = { version = "1.0.171" }
-serde_json = { version = "1.0" }
+serde_json = { version = "1.0", default-features = false }
 
 # crypto [no_std]
 der = { default-features = false, version = "0.6.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,37 +21,40 @@ members = [
 [workspace.dependencies]
 base64 = { version = "0.13", default-features = false, features = ["alloc"] }
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
-cumulus-primitives-core = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-der = { default-features = false, version = "0.6.0" }
+derive_more = "0.99.16"
 env_logger = "0.9.0"
-externalities = { package = "sp-externalities", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 hex = { default-features = false, version = "0.4.3", features = ["alloc"] }
 hex-literal = "0.3.2"
-libsecp256k1 = { version = "0.7.0", default-features = false }
 log = { version = "0.4.14", default-features = false }
-pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-timestamp = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-vesting = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-ring = { version = "0.16.20", default-features = false, features = ["alloc"] }
 rustc-hex = { version = "2.1.0", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
 serde = { version = "1.0.171", features = ["derive"] }
 serde_derive = { version = "1.0.171" }
 serde_json = { version = "1.0" }
-sgx-verify = { path = "sgx-verify", default-features = false }
+
+# crypto [no_std]
+der = { default-features = false, version = "0.6.0" }
+libsecp256k1 = { version = "0.7.0", default-features = false }
+ring = { version = "0.16.20", default-features = false, features = ["alloc"] }
+webpki = { git = "https://github.com/rustls/webpki", version = "=0.102.0-alpha.3", rev = "da923ed", package = "rustls-webpki", default-features = false, features = ["alloc", "ring"] }
+x509-cert = { default-features = false, version = "0.1.0", features = ["alloc"] }
+
+# polkadot-sdk and ecosystem crates [no_std]
+cumulus-primitives-core = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+pallet-timestamp = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+pallet-vesting = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 substrate-fixed = { tag = "v0.5.9", default-features = false, git = "https://github.com/encointer/substrate-fixed.git" }
-teerex-primitives = { path = "../primitives/teerex", default-features = false }
-timestamp = { package = "pallet-timestamp", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-webpki = { git = "https://github.com/rustls/webpki", version = "=0.102.0-alpha.3", rev = "da923ed", package = "rustls-webpki", default-features = false, features = ["alloc", "ring"] }
-x509-cert = { default-features = false, version = "0.1.0", features = ["alloc"] }
 xcm = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
-derive_more = "0.99.16"
+
+# dev-deps [std]
+sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+externalities = { package = "sp-externalities", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }

--- a/claims/Cargo.toml
+++ b/claims/Cargo.toml
@@ -26,11 +26,11 @@ claims-primitives = { package = "claims-primitives", path = "../primitives/claim
 
 [dev-dependencies]
 hex-literal = { workspace = true }
-libsecp256k1 = { workspace = true }
+libsecp256k1 = { workspace = true, features = ["std"] }
 pallet-balances = { workspace = true, features = ["std"] }
 pallet-vesting = { workspace = true, features = ["std"] }
 serde_json = { workspace = true }
-sp-core = { workspace = true }
+sp-core = { workspace = true, features = ["std"] }
 
 [features]
 default = ["std"]

--- a/claims/Cargo.toml
+++ b/claims/Cargo.toml
@@ -33,28 +33,28 @@ serde_json = { workspace = true }
 sp-core = { workspace = true, features = ["std"] }
 
 [features]
-default = ["std"]
+default = [ "std" ]
 no_std = []
 std = [
-    "claims-primitives/std",
-    "frame-support/std",
-    "frame-system/std",
-    "pallet-balances/std",
-    "parity-scale-codec/std",
-    "rustc-hex/std",
-    "scale-info/std",
-    "serde/std",
-    "serde_derive",
-    "sp-io/std",
-    "sp-runtime/std",
-    "sp-std/std",
+	"claims-primitives/std",
+	"frame-support/std",
+	"frame-system/std",
+	"pallet-balances/std",
+	"parity-scale-codec/std",
+	"rustc-hex/std",
+	"scale-info/std",
+	"serde/std",
+	"serde_derive",
+	"sp-io/std",
+	"sp-runtime/std",
+	"sp-std/std",
 ]
 runtime-benchmarks = [
-    "frame-benchmarking",
-    "frame-support/runtime-benchmarks",
-    "frame-system/runtime-benchmarks",
-    "libsecp256k1/hmac",
-    "libsecp256k1/static-context",
+	"frame-benchmarking",
+	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+	"libsecp256k1/hmac",
+	"libsecp256k1/static-context",
 ]
 
-try-runtime = ["frame-support/try-runtime"]
+try-runtime = [ "frame-support/try-runtime" ]

--- a/claims/Cargo.toml
+++ b/claims/Cargo.toml
@@ -27,8 +27,8 @@ claims-primitives = { package = "claims-primitives", path = "../primitives/claim
 [dev-dependencies]
 hex-literal = { workspace = true }
 libsecp256k1 = { workspace = true }
-pallet-balances = { workspace = true }
-pallet-vesting = { workspace = true }
+pallet-balances = { workspace = true, features = ["std"] }
+pallet-vesting = { workspace = true, features = ["std"] }
 serde_json = { workspace = true }
 sp-core = { workspace = true }
 

--- a/claims/Cargo.toml
+++ b/claims/Cargo.toml
@@ -6,31 +6,31 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-libsecp256k1 = { version = "0.7.0", default-features = false, optional = true }
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
-rustc-hex = { version = "2.1.0", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
-serde = { version = "1.0.171", default-features = false }
-serde_derive = { version = "1.0.171", optional = true }
+parity-scale-codec = { workspace = true }
+libsecp256k1 = { workspace = true, optional = true }
+rustc-hex = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true }
+serde_derive = { workspace = true, optional = true }
 
 # substrate dependencies
-frame-benchmarking = { optional = true, default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-frame-system = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-io = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0", features = ["serde"] }
-sp-std = { package = "sp-std", default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+frame-benchmarking = { workspace = true, optional = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 # local
 claims-primitives = { package = "claims-primitives", path = "../primitives/claims", default-features = false, features = ["serde_derive"] }
 
 [dev-dependencies]
-hex-literal = "0.3.3"
-libsecp256k1 = "0.7.0"
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-pallet-vesting = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-serde_json = { version = "1.0" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+hex-literal = { workspace = true }
+libsecp256k1 = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-vesting = { workspace = true }
+serde_json = { workspace = true }
+sp-core = { workspace = true }
 
 [features]
 default = ["std"]
@@ -39,6 +39,7 @@ std = [
     "claims-primitives/std",
     "frame-support/std",
     "frame-system/std",
+    "pallet-balances/std",
     "parity-scale-codec/std",
     "rustc-hex/std",
     "scale-info/std",

--- a/claims/Cargo.toml
+++ b/claims/Cargo.toml
@@ -6,8 +6,8 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-parity-scale-codec = { workspace = true }
 libsecp256k1 = { workspace = true, optional = true }
+parity-scale-codec = { workspace = true }
 rustc-hex = { workspace = true }
 scale-info = { workspace = true }
 serde = { workspace = true }
@@ -29,32 +29,32 @@ hex-literal = { workspace = true }
 libsecp256k1 = { workspace = true, features = ["std"] }
 pallet-balances = { workspace = true, features = ["std"] }
 pallet-vesting = { workspace = true, features = ["std"] }
-serde_json = { workspace = true, features = ["std"]}
+serde_json = { workspace = true, features = ["std"] }
 sp-core = { workspace = true, features = ["std"] }
 
 [features]
-default = [ "std" ]
+default = ["std"]
 
 std = [
-	"claims-primitives/std",
-	"frame-support/std",
-	"frame-system/std",
-	"pallet-balances/std",
-	"parity-scale-codec/std",
-	"rustc-hex/std",
-	"scale-info/std",
-	"serde/std",
-	"serde_derive",
-	"sp-io/std",
-	"sp-runtime/std",
-	"sp-std/std",
+    "claims-primitives/std",
+    "frame-support/std",
+    "frame-system/std",
+    "pallet-balances/std",
+    "parity-scale-codec/std",
+    "rustc-hex/std",
+    "scale-info/std",
+    "serde/std",
+    "serde_derive",
+    "sp-io/std",
+    "sp-runtime/std",
+    "sp-std/std",
 ]
 runtime-benchmarks = [
-	"frame-benchmarking",
-	"frame-support/runtime-benchmarks",
-	"frame-system/runtime-benchmarks",
-	"libsecp256k1/hmac",
-	"libsecp256k1/static-context",
+    "frame-benchmarking",
+    "frame-support/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
+    "libsecp256k1/hmac",
+    "libsecp256k1/static-context",
 ]
 
-try-runtime = [ "frame-support/try-runtime" ]
+try-runtime = ["frame-support/try-runtime"]

--- a/claims/Cargo.toml
+++ b/claims/Cargo.toml
@@ -29,12 +29,12 @@ hex-literal = { workspace = true }
 libsecp256k1 = { workspace = true, features = ["std"] }
 pallet-balances = { workspace = true, features = ["std"] }
 pallet-vesting = { workspace = true, features = ["std"] }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["std"]}
 sp-core = { workspace = true, features = ["std"] }
 
 [features]
 default = [ "std" ]
-no_std = []
+
 std = [
 	"claims-primitives/std",
 	"frame-support/std",

--- a/enclave-bridge/Cargo.toml
+++ b/enclave-bridge/Cargo.toml
@@ -37,9 +37,9 @@ test-utils = { path = "../test-utils", optional = true }
 [dev-dependencies]
 env_logger = { workspace = true }
 externalities = { workspace = true }
-frame-benchmarking = { workspace = true }
+frame-benchmarking = { workspace = true, features = ["std"] }
 hex-literal = { workspace = true }
-pallet-balances = { workspace = true }
+pallet-balances = { workspace = true, features = ["std"] }
 sp-keyring = { workspace = true }
 test-utils = { path = "../test-utils" }
 

--- a/enclave-bridge/Cargo.toml
+++ b/enclave-bridge/Cargo.toml
@@ -67,6 +67,10 @@ runtime-benchmarks = [
 	"pallet-balances",
 	"pallet-timestamp/runtime-benchmarks",
 	"test-utils",
+	"pallet-teerex/runtime-benchmarks"
 ]
 
-try-runtime = [ "frame-support/try-runtime" ]
+try-runtime = [
+	"frame-support/try-runtime", 
+	"pallet-teerex/try-runtime"
+]

--- a/enclave-bridge/Cargo.toml
+++ b/enclave-bridge/Cargo.toml
@@ -54,7 +54,7 @@ std = [
 	"pallet-timestamp/std",
 	"parity-scale-codec/std",
 	"scale-info/std",
-	"serde",
+	"serde/std",
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
@@ -71,6 +71,6 @@ runtime-benchmarks = [
 ]
 
 try-runtime = [
-	"frame-support/try-runtime", 
+	"frame-support/try-runtime",
 	"pallet-teerex/try-runtime"
 ]

--- a/enclave-bridge/Cargo.toml
+++ b/enclave-bridge/Cargo.toml
@@ -9,10 +9,10 @@ license = "MS-RSL"
 edition = "2021"
 
 [dependencies]
-codec = { version = "3.6.1", default-features = false, features = ["derive"], package = "parity-scale-codec" }
-log = { version = "0.4.14", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
-serde = { version = "1.0.171", features = ["derive"], optional = true }
+parity-scale-codec = { workspace = true }
+log = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true, optional = true }
 
 # local
 enclave-bridge-primitives = { path = "../primitives/enclave-bridge", default-features = false }
@@ -20,33 +20,33 @@ pallet-teerex = { path = "../teerex", default-features = false }
 teerex-primitives = { path = "../primitives/teerex", default-features = false }
 
 # substrate dependencies
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-timestamp = { package = "pallet-timestamp", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
+timestamp = { workspace = true }
 
 # benchmarking
-frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-hex-literal = { version = "0.3.2", optional = true }
-pallet-balances = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-test-utils = { path = "../test-utils", default-features = false, optional = true }
+frame-benchmarking = { workspace = true, optional = true }
+hex-literal = { workspace = true, optional = true }
+pallet-balances = { workspace = true, optional = true }
+test-utils = { path = "../test-utils", optional = true }
 
 [dev-dependencies]
-env_logger = "0.9.0"
-externalities = { package = "sp-externalities", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-hex-literal = "0.3.2"
-pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+env_logger = { workspace = true }
+externalities = { workspace = true }
+frame-benchmarking = { workspace = true }
+hex-literal = { workspace = true }
+pallet-balances = { workspace = true }
+sp-keyring = { workspace = true }
 test-utils = { path = "../test-utils" }
 
 [features]
 default = ["std"]
 std = [
-    "codec/std",
+    "parity-scale-codec/std",
     "enclave-bridge-primitives/std",
     "frame-support/std",
     "frame-system/std",

--- a/enclave-bridge/Cargo.toml
+++ b/enclave-bridge/Cargo.toml
@@ -44,29 +44,29 @@ sp-keyring = { workspace = true }
 test-utils = { path = "../test-utils" }
 
 [features]
-default = ["std"]
+default = [ "std" ]
 std = [
-    "parity-scale-codec/std",
-    "enclave-bridge-primitives/std",
-    "frame-support/std",
-    "frame-system/std",
-    "log/std",
-    "pallet-teerex/std",
-    "scale-info/std",
-    "serde",
-    "sp-core/std",
-    "sp-io/std",
-    "sp-runtime/std",
-    "sp-std/std",
-    "teerex-primitives/std",
-    "pallet-timestamp/std",
+	"enclave-bridge-primitives/std",
+	"frame-support/std",
+	"frame-system/std",
+	"log/std",
+	"pallet-teerex/std",
+	"pallet-timestamp/std",
+	"parity-scale-codec/std",
+	"scale-info/std",
+	"serde",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-runtime/std",
+	"sp-std/std",
+	"teerex-primitives/std",
 ]
 runtime-benchmarks = [
-    "frame-benchmarking",
-    "hex-literal",
-    "pallet-balances",
-    "test-utils",
-    "pallet-timestamp/runtime-benchmarks",
+	"frame-benchmarking",
+	"hex-literal",
+	"pallet-balances",
+	"pallet-timestamp/runtime-benchmarks",
+	"test-utils",
 ]
 
-try-runtime = ["frame-support/try-runtime"]
+try-runtime = [ "frame-support/try-runtime" ]

--- a/enclave-bridge/Cargo.toml
+++ b/enclave-bridge/Cargo.toml
@@ -26,7 +26,7 @@ sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
-timestamp = { workspace = true }
+pallet-timestamp = { workspace = true }
 
 # benchmarking
 frame-benchmarking = { workspace = true, optional = true }
@@ -59,14 +59,14 @@ std = [
     "sp-runtime/std",
     "sp-std/std",
     "teerex-primitives/std",
-    "timestamp/std",
+    "pallet-timestamp/std",
 ]
 runtime-benchmarks = [
     "frame-benchmarking",
     "hex-literal",
     "pallet-balances",
     "test-utils",
-    "timestamp/runtime-benchmarks",
+    "pallet-timestamp/runtime-benchmarks",
 ]
 
 try-runtime = ["frame-support/try-runtime"]

--- a/enclave-bridge/Cargo.toml
+++ b/enclave-bridge/Cargo.toml
@@ -9,8 +9,8 @@ license = "MS-RSL"
 edition = "2021"
 
 [dependencies]
-parity-scale-codec = { workspace = true }
 log = { workspace = true }
+parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 serde = { workspace = true, optional = true }
 
@@ -22,11 +22,11 @@ teerex-primitives = { path = "../primitives/teerex", default-features = false }
 # substrate dependencies
 frame-support = { workspace = true }
 frame-system = { workspace = true }
+pallet-timestamp = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
-pallet-timestamp = { workspace = true }
 
 # benchmarking
 frame-benchmarking = { workspace = true, optional = true }
@@ -44,33 +44,33 @@ sp-keyring = { workspace = true }
 test-utils = { path = "../test-utils" }
 
 [features]
-default = [ "std" ]
+default = ["std"]
 std = [
-	"enclave-bridge-primitives/std",
-	"frame-support/std",
-	"frame-system/std",
-	"log/std",
-	"pallet-teerex/std",
-	"pallet-timestamp/std",
-	"parity-scale-codec/std",
-	"scale-info/std",
-	"serde/std",
-	"sp-core/std",
-	"sp-io/std",
-	"sp-runtime/std",
-	"sp-std/std",
-	"teerex-primitives/std",
+    "enclave-bridge-primitives/std",
+    "frame-support/std",
+    "frame-system/std",
+    "log/std",
+    "pallet-teerex/std",
+    "pallet-timestamp/std",
+    "parity-scale-codec/std",
+    "scale-info/std",
+    "serde/std",
+    "sp-core/std",
+    "sp-io/std",
+    "sp-runtime/std",
+    "sp-std/std",
+    "teerex-primitives/std",
 ]
 runtime-benchmarks = [
-	"frame-benchmarking",
-	"hex-literal",
-	"pallet-balances",
-	"pallet-timestamp/runtime-benchmarks",
-	"test-utils",
-	"pallet-teerex/runtime-benchmarks"
+    "frame-benchmarking",
+    "hex-literal",
+    "pallet-balances",
+    "pallet-timestamp/runtime-benchmarks",
+    "test-utils",
+    "pallet-teerex/runtime-benchmarks",
 ]
 
 try-runtime = [
-	"frame-support/try-runtime",
-	"pallet-teerex/try-runtime"
+    "frame-support/try-runtime",
+    "pallet-teerex/try-runtime",
 ]

--- a/enclave-bridge/src/benchmarking.rs
+++ b/enclave-bridge/src/benchmarking.rs
@@ -20,10 +20,10 @@
 #![cfg(any(test, feature = "runtime-benchmarks"))]
 
 use super::*;
-use codec::{Decode, Encode};
 use frame_benchmarking::{benchmarks, v2::*};
 use frame_system::RawOrigin;
 use pallet_teerex::Pallet as Teerex;
+use parity_scale_codec::{Decode, Encode};
 use sp_runtime::traits::{Bounded, Hash, StaticLookup};
 use sp_std::vec;
 use teerex_primitives::{MultiEnclave, SgxEnclave};

--- a/enclave-bridge/src/lib.rs
+++ b/enclave-bridge/src/lib.rs
@@ -64,7 +64,9 @@ pub mod pallet {
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
 
 	#[pallet::config]
-	pub trait Config: frame_system::Config + timestamp::Config + pallet_teerex::Config {
+	pub trait Config:
+		frame_system::Config + pallet_timestamp::Config + pallet_teerex::Config
+	{
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		type Currency: Currency<<Self as frame_system::Config>::AccountId>;
 		type WeightInfo: WeightInfo;

--- a/enclave-bridge/src/lib.rs
+++ b/enclave-bridge/src/lib.rs
@@ -18,7 +18,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use crate::weights::WeightInfo;
-use codec::Encode;
 use enclave_bridge_primitives::{
 	Request, ShardConfig, ShardIdentifier, ShardSignerStatus as ShardSignerStatusGeneric,
 	UpgradableShardConfig, ENCLAVE_BRIDGE, MAX_SHARD_STATUS_SIGNER_COUNT,
@@ -31,6 +30,7 @@ use frame_support::{
 };
 use frame_system::{self, ensure_signed, pallet_prelude::BlockNumberFor};
 use pallet_teerex::Pallet as Teerex;
+use parity_scale_codec::Encode;
 use sp_core::{bounded::BoundedVec, H256};
 use sp_runtime::traits::{SaturatedConversion, Saturating};
 use sp_std::{prelude::*, str, vec};

--- a/enclave-bridge/src/mock.rs
+++ b/enclave-bridge/src/mock.rs
@@ -51,7 +51,7 @@ frame_support::construct_runtime!(
 	{
 		System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-		Timestamp: timestamp::{Pallet, Call, Storage, Inherent},
+		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 		Teerex: pallet_teerex::{Pallet, Call, Storage, Event<T>},
 		EnclaveBridge: pallet_enclave_bridge::{Pallet, Call, Storage, Event<T>},
 	}
@@ -114,7 +114,7 @@ parameter_types! {
 
 pub type Moment = u64;
 
-impl timestamp::Config for Test {
+impl pallet_timestamp::Config for Test {
 	type Moment = Moment;
 	type OnTimestampSet = ();
 	type MinimumPeriod = MinimumPeriod;

--- a/enclave-bridge/src/tests/mod.rs
+++ b/enclave-bridge/src/tests/mod.rs
@@ -16,8 +16,8 @@
 */
 
 use crate::mock::*;
-use codec::{Decode, Encode};
 use frame_support::assert_ok;
+use parity_scale_codec::{Decode, Encode};
 use teerex_primitives::{EnclaveFingerprint, MultiEnclave, SgxEnclave};
 use test_utils::TestEnclave;
 

--- a/enclave-bridge/src/tests/mod.rs
+++ b/enclave-bridge/src/tests/mod.rs
@@ -32,7 +32,7 @@ fn get_bonding_account(enclave: &MultiEnclave<Vec<u8>>) -> AccountId {
 }
 
 fn now() -> u64 {
-	<timestamp::Pallet<Test>>::get()
+	<pallet_timestamp::Pallet<Test>>::get()
 }
 
 fn register_sovereign_test_enclave(

--- a/parentchain/Cargo.toml
+++ b/parentchain/Cargo.toml
@@ -9,8 +9,8 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-parity-scale-codec = { workspace = true }
 log = { workspace = true }
+parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 serde = { workspace = true, optional = true }
 
@@ -28,19 +28,19 @@ env_logger = { workspace = true }
 sp-keyring = { workspace = true }
 
 [features]
-default = [ "std" ]
+default = ["std"]
 std = [
-	"frame-support/std",
-	"frame-system/std",
-	"log/std",
-	"pallet-balances/std",
-	"parity-scale-codec/std",
-	"scale-info/std",
-	"serde/std",
-	"sp-core/std",
-	"sp-io/std",
-	"sp-runtime/std",
-	"sp-std/std",
+    "frame-support/std",
+    "frame-system/std",
+    "log/std",
+    "pallet-balances/std",
+    "parity-scale-codec/std",
+    "scale-info/std",
+    "serde/std",
+    "sp-core/std",
+    "sp-io/std",
+    "sp-runtime/std",
+    "sp-std/std",
 ]
 
-try-runtime = [ "frame-support/try-runtime" ]
+try-runtime = ["frame-support/try-runtime"]

--- a/parentchain/Cargo.toml
+++ b/parentchain/Cargo.toml
@@ -36,7 +36,7 @@ std = [
 	"pallet-balances/std",
 	"parity-scale-codec/std",
 	"scale-info/std",
-	"serde",
+	"serde/std",
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",

--- a/parentchain/Cargo.toml
+++ b/parentchain/Cargo.toml
@@ -28,19 +28,19 @@ env_logger = { workspace = true }
 sp-keyring = { workspace = true }
 
 [features]
-default = ["std"]
+default = [ "std" ]
 std = [
-    "parity-scale-codec/std",
-    "frame-support/std",
-    "frame-system/std",
-    "log/std",
-    "pallet-balances/std",
-    "scale-info/std",
-    "serde",
-    "sp-core/std",
-    "sp-io/std",
-    "sp-runtime/std",
-    "sp-std/std",
+	"frame-support/std",
+	"frame-system/std",
+	"log/std",
+	"pallet-balances/std",
+	"parity-scale-codec/std",
+	"scale-info/std",
+	"serde",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-runtime/std",
+	"sp-std/std",
 ]
 
-try-runtime = ["frame-support/try-runtime"]
+try-runtime = [ "frame-support/try-runtime" ]

--- a/parentchain/Cargo.toml
+++ b/parentchain/Cargo.toml
@@ -9,28 +9,28 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-codec = { version = "3.6.1", default-features = false, features = ["derive"], package = "parity-scale-codec" }
-log = { version = "0.4.14", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
-serde = { version = "1.0.171", features = ["derive"], optional = true }
+parity-scale-codec = { workspace = true }
+log = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true, optional = true }
 
 # substrate dependencies
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+pallet-balances = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 [dev-dependencies]
-env_logger = "0.9.0"
-sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+env_logger = { workspace = true }
+sp-keyring = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
-    "codec/std",
+    "parity-scale-codec/std",
     "frame-support/std",
     "frame-system/std",
     "log/std",

--- a/primitives/claims/Cargo.toml
+++ b/primitives/claims/Cargo.toml
@@ -19,14 +19,14 @@ sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 
 [features]
-default = ["std"]
-serde_derive = ["serde"]
+default = [ "std" ]
+serde_derive = [ "serde" ]
 std = [
-    "parity-scale-codec/std",
-    "rustc-hex/std",
-    "scale-info/std",
-    "serde/std",
-    "sp-io/std",
-    "sp-runtime/std",
-    "sp-std/std",
+	"parity-scale-codec/std",
+	"rustc-hex/std",
+	"scale-info/std",
+	"serde/std",
+	"sp-io/std",
+	"sp-runtime/std",
+	"sp-std/std",
 ]

--- a/primitives/claims/Cargo.toml
+++ b/primitives/claims/Cargo.toml
@@ -8,15 +8,15 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
-rustc-hex = { version = "2.1.0", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
-serde = { version = "1.0.171", default-features = false, optional = true, features = ["alloc", "derive"] }
+parity-scale-codec = { workspace = true }
+rustc-hex = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true, optional = true }
 
 # substrate dependencies
-sp-io = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 [features]
 default = ["std"]

--- a/primitives/claims/Cargo.toml
+++ b/primitives/claims/Cargo.toml
@@ -19,14 +19,14 @@ sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 
 [features]
-default = [ "std" ]
-serde_derive = [ "serde" ]
+default = ["std"]
+serde_derive = ["serde"]
 std = [
-	"parity-scale-codec/std",
-	"rustc-hex/std",
-	"scale-info/std",
-	"serde/std",
-	"sp-io/std",
-	"sp-runtime/std",
-	"sp-std/std",
+    "parity-scale-codec/std",
+    "rustc-hex/std",
+    "scale-info/std",
+    "serde/std",
+    "sp-io/std",
+    "sp-runtime/std",
+    "sp-std/std",
 ]

--- a/primitives/common/Cargo.toml
+++ b/primitives/common/Cargo.toml
@@ -8,8 +8,8 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-parity-scale-codec = { workspace = true }
 derive_more = { workspace = true }
+parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 
 # substrate deps
@@ -18,11 +18,11 @@ sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 
 [features]
-default = [ "std" ]
+default = ["std"]
 std = [
-	"parity-scale-codec/std",
-	"scale-info/std",
-	"sp-core/std",
-	"sp-runtime/std",
-	"sp-std/std",
+    "parity-scale-codec/std",
+    "scale-info/std",
+    "sp-core/std",
+    "sp-runtime/std",
+    "sp-std/std",
 ]

--- a/primitives/common/Cargo.toml
+++ b/primitives/common/Cargo.toml
@@ -8,19 +8,19 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-codec = { version = "3.6.1", default-features = false, features = ["derive"], package = "parity-scale-codec" }
-derive_more = "0.99.16"
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+parity-scale-codec = { workspace = true }
+derive_more = { workspace = true }
+scale-info = { workspace = true }
 
 # substrate deps
-sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
-    "codec/std",
+    "parity-scale-codec/std",
     "scale-info/std",
     "sp-core/std",
     "sp-runtime/std",

--- a/primitives/common/Cargo.toml
+++ b/primitives/common/Cargo.toml
@@ -18,11 +18,11 @@ sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 
 [features]
-default = ["std"]
+default = [ "std" ]
 std = [
-    "parity-scale-codec/std",
-    "scale-info/std",
-    "sp-core/std",
-    "sp-runtime/std",
-    "sp-std/std",
+	"parity-scale-codec/std",
+	"scale-info/std",
+	"sp-core/std",
+	"sp-runtime/std",
+	"sp-std/std",
 ]

--- a/primitives/common/src/lib.rs
+++ b/primitives/common/src/lib.rs
@@ -17,8 +17,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 //!Primitives for all pallets
 extern crate derive_more;
-use codec::{Decode, Encode};
 use derive_more::From;
+use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_core::{bounded::BoundedVec, ConstU32, H256};
 use sp_runtime::MultiSigner;

--- a/primitives/enclave-bridge/Cargo.toml
+++ b/primitives/enclave-bridge/Cargo.toml
@@ -24,14 +24,14 @@ sp-std = { workspace = true }
 hex-literal = { workspace = true }
 
 [features]
-default = ["std"]
+default = [ "std" ]
 std = [
-    "parity-scale-codec/std",
-    "common-primitives/std",
-    "scale-info/std",
-    "serde/std",
-    "sp-core/std",
-    "sp-io/std",
-    "sp-runtime/std",
-    "sp-std/std",
+	"common-primitives/std",
+	"parity-scale-codec/std",
+	"scale-info/std",
+	"serde/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-runtime/std",
+	"sp-std/std",
 ]

--- a/primitives/enclave-bridge/Cargo.toml
+++ b/primitives/enclave-bridge/Cargo.toml
@@ -8,25 +8,25 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-codec = { version = "3.6.1", default-features = false, features = ["derive"], package = "parity-scale-codec" }
+parity-scale-codec = { workspace = true }
 common-primitives = { path = "../common", default-features = false }
-log = { version = "0.4.14", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
-serde = { version = "1.0.171", default-features = false }
+log = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true }
 
 # substrate dependencies
-sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 [dev-dependencies]
-hex-literal = "0.3.4"
+hex-literal = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
-    "codec/std",
+    "parity-scale-codec/std",
     "common-primitives/std",
     "scale-info/std",
     "serde/std",

--- a/primitives/enclave-bridge/Cargo.toml
+++ b/primitives/enclave-bridge/Cargo.toml
@@ -8,9 +8,9 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-parity-scale-codec = { workspace = true }
 common-primitives = { path = "../common", default-features = false }
 log = { workspace = true }
+parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 serde = { workspace = true }
 
@@ -24,14 +24,14 @@ sp-std = { workspace = true }
 hex-literal = { workspace = true }
 
 [features]
-default = [ "std" ]
+default = ["std"]
 std = [
-	"common-primitives/std",
-	"parity-scale-codec/std",
-	"scale-info/std",
-	"serde/std",
-	"sp-core/std",
-	"sp-io/std",
-	"sp-runtime/std",
-	"sp-std/std",
+    "common-primitives/std",
+    "parity-scale-codec/std",
+    "scale-info/std",
+    "serde/std",
+    "sp-core/std",
+    "sp-io/std",
+    "sp-runtime/std",
+    "sp-std/std",
 ]

--- a/primitives/enclave-bridge/src/lib.rs
+++ b/primitives/enclave-bridge/src/lib.rs
@@ -17,8 +17,8 @@
 
 //!Primitives for enclave-bridge
 #![cfg_attr(not(feature = "std"), no_std)]
-use codec::{Decode, Encode};
 pub use common_primitives::{EnclaveFingerprint, ShardIdentifier};
+use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_std::prelude::*;
 

--- a/primitives/sidechain/Cargo.toml
+++ b/primitives/sidechain/Cargo.toml
@@ -8,16 +8,16 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
-serde = { version = "1.0.171", default-features = false }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true }
 
 
 # substrate dependencies
-sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 
 [features]
@@ -26,7 +26,7 @@ full_crypto = [
     "sp-core/full_crypto",
 ]
 std = [
-    "codec/std",
+    "parity-scale-codec/std",
     "scale-info/std",
     "serde/std",
     "sp-core/std",

--- a/primitives/sidechain/Cargo.toml
+++ b/primitives/sidechain/Cargo.toml
@@ -21,14 +21,14 @@ sp-std = { workspace = true }
 
 
 [features]
-default = [ "full_crypto", "std" ]
-full_crypto = [ "sp-core/full_crypto" ]
+default = ["full_crypto", "std"]
+full_crypto = ["sp-core/full_crypto"]
 std = [
-	"parity-scale-codec/std",
-	"scale-info/std",
-	"serde/std",
-	"sp-core/std",
-	"sp-io/std",
-	"sp-runtime/std",
-	"sp-std/std",
+    "parity-scale-codec/std",
+    "scale-info/std",
+    "serde/std",
+    "sp-core/std",
+    "sp-io/std",
+    "sp-runtime/std",
+    "sp-std/std",
 ]

--- a/primitives/sidechain/Cargo.toml
+++ b/primitives/sidechain/Cargo.toml
@@ -21,16 +21,14 @@ sp-std = { workspace = true }
 
 
 [features]
-default = ["std", "full_crypto"]
-full_crypto = [
-    "sp-core/full_crypto",
-]
+default = [ "full_crypto", "std" ]
+full_crypto = [ "sp-core/full_crypto" ]
 std = [
-    "parity-scale-codec/std",
-    "scale-info/std",
-    "serde/std",
-    "sp-core/std",
-    "sp-io/std",
-    "sp-runtime/std",
-    "sp-std/std",
+	"parity-scale-codec/std",
+	"scale-info/std",
+	"serde/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-runtime/std",
+	"sp-std/std",
 ]

--- a/primitives/sidechain/src/lib.rs
+++ b/primitives/sidechain/src/lib.rs
@@ -17,7 +17,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Decode, Encode};
+use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_core::H256;
 

--- a/primitives/teeracle/Cargo.toml
+++ b/primitives/teeracle/Cargo.toml
@@ -19,5 +19,5 @@ sp-std = { workspace = true }
 
 
 [features]
-default = [ "std" ]
-std = [ "common-primitives/std", "sp-std/std", "substrate-fixed/std" ]
+default = ["std"]
+std = ["common-primitives/std", "sp-std/std", "substrate-fixed/std"]

--- a/primitives/teeracle/Cargo.toml
+++ b/primitives/teeracle/Cargo.toml
@@ -12,10 +12,10 @@ edition = "2021"
 common-primitives = { path = "../common", default-features = false }
 
 # encointer
-substrate-fixed = { tag = "v0.5.9", default-features = false, git = "https://github.com/encointer/substrate-fixed.git" }
+substrate-fixed = { workspace = true }
 
 # substrate
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+sp-std = { workspace = true }
 
 
 [features]

--- a/primitives/teeracle/Cargo.toml
+++ b/primitives/teeracle/Cargo.toml
@@ -19,9 +19,5 @@ sp-std = { workspace = true }
 
 
 [features]
-default = ["std"]
-std = [
-    "common-primitives/std",
-    "sp-std/std",
-    "substrate-fixed/std",
-]
+default = [ "std" ]
+std = [ "common-primitives/std", "sp-std/std", "substrate-fixed/std" ]

--- a/primitives/teerex/Cargo.toml
+++ b/primitives/teerex/Cargo.toml
@@ -8,10 +8,10 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-parity-scale-codec = { workspace = true }
 common-primitives = { path = "../common", default-features = false }
 derive_more = { workspace = true }
 log = { workspace = true }
+parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 serde = { workspace = true }
 
@@ -24,14 +24,14 @@ sp-std = { workspace = true }
 hex-literal = { workspace = true }
 
 [features]
-default = [ "std" ]
+default = ["std"]
 std = [
-	"common-primitives/std",
-	"log/std",
-	"parity-scale-codec/std",
-	"scale-info/std",
-	"serde/std",
-	"sp-core/std",
-	"sp-runtime/std",
-	"sp-std/std",
+    "common-primitives/std",
+    "log/std",
+    "parity-scale-codec/std",
+    "scale-info/std",
+    "serde/std",
+    "sp-core/std",
+    "sp-runtime/std",
+    "sp-std/std",
 ]

--- a/primitives/teerex/Cargo.toml
+++ b/primitives/teerex/Cargo.toml
@@ -8,25 +8,25 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-codec = { version = "3.6.1", default-features = false, features = ["derive"], package = "parity-scale-codec" }
+parity-scale-codec = { workspace = true }
 common-primitives = { path = "../common", default-features = false }
-derive_more = "0.99.16"
-log = { version = "0.4.14", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
-serde = { version = "1.0.171", default-features = false }
+derive_more = { workspace = true }
+log = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true }
 
 # substrate dependencies
-sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 [dev-dependencies]
-hex-literal = "0.3.4"
+hex-literal = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
-    "codec/std",
+    "parity-scale-codec/std",
     "common-primitives/std",
     "log/std",
     "scale-info/std",

--- a/primitives/teerex/Cargo.toml
+++ b/primitives/teerex/Cargo.toml
@@ -24,14 +24,14 @@ sp-std = { workspace = true }
 hex-literal = { workspace = true }
 
 [features]
-default = ["std"]
+default = [ "std" ]
 std = [
-    "parity-scale-codec/std",
-    "common-primitives/std",
-    "log/std",
-    "scale-info/std",
-    "serde/std",
-    "sp-core/std",
-    "sp-runtime/std",
-    "sp-std/std",
+	"common-primitives/std",
+	"log/std",
+	"parity-scale-codec/std",
+	"scale-info/std",
+	"serde/std",
+	"sp-core/std",
+	"sp-runtime/std",
+	"sp-std/std",
 ]

--- a/primitives/teerex/src/lib.rs
+++ b/primitives/teerex/src/lib.rs
@@ -18,9 +18,9 @@
 //!Primitives for teerex
 #![cfg_attr(not(feature = "std"), no_std)]
 extern crate derive_more;
-use codec::{Decode, Encode};
 pub use common_primitives::{AnySigner, EnclaveFingerprint, OpaqueSigner};
 use derive_more::From;
+use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_runtime::MultiSigner;

--- a/primitives/xcm-transactor/Cargo.toml
+++ b/primitives/xcm-transactor/Cargo.toml
@@ -8,26 +8,26 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
+parity-scale-codec = { workspace = true }
 # local
 common-primitives = { path = "../common", default-features = false }
 
 # substrate
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+frame-support = { workspace = true }
+sp-std = { workspace = true }
 
 # xcm/polkadot
-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0", default-features = false }
+xcm = { workspace = true }
 
 # cumulus
-cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0", default-features = false }
+cumulus-primitives-core = { workspace = true }
 
 [features]
 default = ["std"]
 ksm = []
 dot = []
 std = [
-    "codec/std",
+    "parity-scale-codec/std",
     "common-primitives/std",
     "cumulus-primitives-core/std",
     "frame-support/std",

--- a/primitives/xcm-transactor/Cargo.toml
+++ b/primitives/xcm-transactor/Cargo.toml
@@ -23,14 +23,14 @@ xcm = { workspace = true }
 cumulus-primitives-core = { workspace = true }
 
 [features]
-default = [ "std" ]
+default = ["std"]
 ksm = []
 dot = []
 std = [
-	"common-primitives/std",
-	"cumulus-primitives-core/std",
-	"frame-support/std",
-	"parity-scale-codec/std",
-	"sp-std/std",
-	"xcm/std",
+    "common-primitives/std",
+    "cumulus-primitives-core/std",
+    "frame-support/std",
+    "parity-scale-codec/std",
+    "sp-std/std",
+    "xcm/std",
 ]

--- a/primitives/xcm-transactor/Cargo.toml
+++ b/primitives/xcm-transactor/Cargo.toml
@@ -23,14 +23,14 @@ xcm = { workspace = true }
 cumulus-primitives-core = { workspace = true }
 
 [features]
-default = ["std"]
+default = [ "std" ]
 ksm = []
 dot = []
 std = [
-    "parity-scale-codec/std",
-    "common-primitives/std",
-    "cumulus-primitives-core/std",
-    "frame-support/std",
-    "sp-std/std",
-    "xcm/std",
+	"common-primitives/std",
+	"cumulus-primitives-core/std",
+	"frame-support/std",
+	"parity-scale-codec/std",
+	"sp-std/std",
+	"xcm/std",
 ]

--- a/primitives/xcm-transactor/src/lib.rs
+++ b/primitives/xcm-transactor/src/lib.rs
@@ -16,12 +16,12 @@
 */
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Decode, Encode, FullCodec};
 pub use cumulus_primitives_core::ParaId;
 use frame_support::{
 	pallet_prelude::{Get, PhantomData},
 	RuntimeDebug,
 };
+use parity_scale_codec::{Decode, Encode, FullCodec};
 use sp_std::vec;
 use xcm::{latest::Weight as XcmWeight, prelude::*};
 

--- a/sidechain/Cargo.toml
+++ b/sidechain/Cargo.toml
@@ -57,7 +57,7 @@ std = [
 	"pallet-timestamp/std",
 	"parity-scale-codec/std",
 	"scale-info/std",
-	"serde",
+	"serde/std",
 	"sidechain-primitives/std",
 	"sp-core/std",
 	"sp-io/std",

--- a/sidechain/Cargo.toml
+++ b/sidechain/Cargo.toml
@@ -9,7 +9,7 @@ license = "MS-RSL"
 edition = "2021"
 
 [dependencies]
-parity-scale-codec = { workspace = true }
+parity-scale-codec = { workspace = true, features = ["full"] }
 log = { workspace = true }
 scale-info = { workspace = true }
 serde = { workspace = true, optional = true }

--- a/sidechain/Cargo.toml
+++ b/sidechain/Cargo.toml
@@ -39,9 +39,9 @@ test-utils = { path = "../test-utils", optional = true }
 [dev-dependencies]
 env_logger = { workspace = true }
 externalities = { workspace = true }
-frame-benchmarking = { workspace = true }
+frame-benchmarking = { workspace = true, features = ["std"] }
 hex-literal = { workspace = true }
-pallet-balances = { workspace = true }
+pallet-balances = { workspace = true, features = ["std"] }
 sp-keyring = { workspace = true }
 test-utils = { path = "../test-utils" }
 

--- a/sidechain/Cargo.toml
+++ b/sidechain/Cargo.toml
@@ -9,10 +9,10 @@ license = "MS-RSL"
 edition = "2021"
 
 [dependencies]
-codec = { version = "3.6.1", default-features = false, features = ["derive"], package = "parity-scale-codec" }
-log = { version = "0.4.14", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
-serde = { version = "1.0.171", features = ["derive"], optional = true }
+parity-scale-codec = { workspace = true }
+log = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true, optional = true }
 
 # local
 enclave-bridge-primitives = { path = "../primitives/enclave-bridge", default-features = false }
@@ -21,34 +21,34 @@ pallet-teerex = { path = "../teerex", default-features = false }
 sidechain-primitives = { path = "../primitives/sidechain", default-features = false }
 
 # substrate dependencies
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-timestamp = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+pallet-timestamp = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 # benchmarking
-frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-hex-literal = { version = "0.3.2", optional = true }
-pallet-balances = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+frame-benchmarking = { workspace = true, optional = true }
+hex-literal ={ workspace = true, optional = true }
+pallet-balances = { workspace = true, optional = true }
 teerex-primitives = { path = "../primitives/teerex", default-features = false }
-test-utils = { path = "../test-utils", default-features = false, optional = true }
+test-utils = { path = "../test-utils", optional = true }
 
 [dev-dependencies]
-env_logger = "0.9.0"
-externalities = { package = "sp-externalities", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-hex-literal = "0.3.2"
-pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+env_logger = { workspace = true }
+externalities = { workspace = true }
+frame-benchmarking = { workspace = true }
+hex-literal = { workspace = true }
+pallet-balances = { workspace = true }
+sp-keyring = { workspace = true }
 test-utils = { path = "../test-utils" }
 
 [features]
 default = ["std"]
 std = [
-    "codec/std",
+    "parity-scale-codec/std",
     "enclave-bridge-primitives/std",
     "frame-support/std",
     "frame-system/std",

--- a/sidechain/Cargo.toml
+++ b/sidechain/Cargo.toml
@@ -71,6 +71,12 @@ runtime-benchmarks = [
 	"pallet-balances",
 	"pallet-timestamp/runtime-benchmarks",
 	"test-utils",
+	"pallet-enclave-bridge/runtime-benchmarks",
+	"pallet-teerex/runtime-benchmarks"
 ]
 
-try-runtime = [ "frame-support/try-runtime" ]
+try-runtime = [
+	"frame-support/try-runtime",
+	"pallet-enclave-bridge/try-runtime",
+	"pallet-teerex/try-runtime"
+]

--- a/sidechain/Cargo.toml
+++ b/sidechain/Cargo.toml
@@ -9,8 +9,8 @@ license = "MS-RSL"
 edition = "2021"
 
 [dependencies]
-parity-scale-codec = { workspace = true, features = ["full"] }
 log = { workspace = true }
+parity-scale-codec = { workspace = true, features = ["full"] }
 scale-info = { workspace = true }
 serde = { workspace = true, optional = true }
 
@@ -31,7 +31,7 @@ sp-std = { workspace = true }
 
 # benchmarking
 frame-benchmarking = { workspace = true, optional = true }
-hex-literal ={ workspace = true, optional = true }
+hex-literal = { workspace = true, optional = true }
 pallet-balances = { workspace = true, optional = true }
 teerex-primitives = { path = "../primitives/teerex", default-features = false }
 test-utils = { path = "../test-utils", optional = true }
@@ -46,37 +46,37 @@ sp-keyring = { workspace = true }
 test-utils = { path = "../test-utils" }
 
 [features]
-default = [ "std" ]
+default = ["std"]
 std = [
-	"enclave-bridge-primitives/std",
-	"frame-support/std",
-	"frame-system/std",
-	"log/std",
-	"pallet-enclave-bridge/std",
-	"pallet-teerex/std",
-	"pallet-timestamp/std",
-	"parity-scale-codec/std",
-	"scale-info/std",
-	"serde/std",
-	"sidechain-primitives/std",
-	"sp-core/std",
-	"sp-io/std",
-	"sp-runtime/std",
-	"sp-std/std",
-	"teerex-primitives/std",
+    "enclave-bridge-primitives/std",
+    "frame-support/std",
+    "frame-system/std",
+    "log/std",
+    "pallet-enclave-bridge/std",
+    "pallet-teerex/std",
+    "pallet-timestamp/std",
+    "parity-scale-codec/std",
+    "scale-info/std",
+    "serde/std",
+    "sidechain-primitives/std",
+    "sp-core/std",
+    "sp-io/std",
+    "sp-runtime/std",
+    "sp-std/std",
+    "teerex-primitives/std",
 ]
 runtime-benchmarks = [
-	"frame-benchmarking",
-	"hex-literal",
-	"pallet-balances",
-	"pallet-timestamp/runtime-benchmarks",
-	"test-utils",
-	"pallet-enclave-bridge/runtime-benchmarks",
-	"pallet-teerex/runtime-benchmarks"
+    "frame-benchmarking",
+    "hex-literal",
+    "pallet-balances",
+    "pallet-timestamp/runtime-benchmarks",
+    "test-utils",
+    "pallet-enclave-bridge/runtime-benchmarks",
+    "pallet-teerex/runtime-benchmarks",
 ]
 
 try-runtime = [
-	"frame-support/try-runtime",
-	"pallet-enclave-bridge/try-runtime",
-	"pallet-teerex/try-runtime"
+    "frame-support/try-runtime",
+    "pallet-enclave-bridge/try-runtime",
+    "pallet-teerex/try-runtime",
 ]

--- a/sidechain/Cargo.toml
+++ b/sidechain/Cargo.toml
@@ -46,31 +46,31 @@ sp-keyring = { workspace = true }
 test-utils = { path = "../test-utils" }
 
 [features]
-default = ["std"]
+default = [ "std" ]
 std = [
-    "parity-scale-codec/std",
-    "enclave-bridge-primitives/std",
-    "frame-support/std",
-    "frame-system/std",
-    "log/std",
-    "pallet-enclave-bridge/std",
-    "pallet-teerex/std",
-    "pallet-timestamp/std",
-    "scale-info/std",
-    "serde",
-    "sidechain-primitives/std",
-    "sp-core/std",
-    "sp-io/std",
-    "sp-runtime/std",
-    "sp-std/std",
-    "teerex-primitives/std",
+	"enclave-bridge-primitives/std",
+	"frame-support/std",
+	"frame-system/std",
+	"log/std",
+	"pallet-enclave-bridge/std",
+	"pallet-teerex/std",
+	"pallet-timestamp/std",
+	"parity-scale-codec/std",
+	"scale-info/std",
+	"serde",
+	"sidechain-primitives/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-runtime/std",
+	"sp-std/std",
+	"teerex-primitives/std",
 ]
 runtime-benchmarks = [
-    "frame-benchmarking",
-    "hex-literal",
-    "pallet-balances",
-    "pallet-timestamp/runtime-benchmarks",
-    "test-utils",
+	"frame-benchmarking",
+	"hex-literal",
+	"pallet-balances",
+	"pallet-timestamp/runtime-benchmarks",
+	"test-utils",
 ]
 
-try-runtime = ["frame-support/try-runtime"]
+try-runtime = [ "frame-support/try-runtime" ]

--- a/sidechain/src/benchmarking.rs
+++ b/sidechain/src/benchmarking.rs
@@ -20,10 +20,10 @@
 #![cfg(any(test, feature = "runtime-benchmarks"))]
 
 use super::*;
-use codec::Encode;
 use frame_benchmarking::{account, benchmarks};
 use frame_system::RawOrigin;
 use pallet_teerex::Pallet as Teerex;
+use parity_scale_codec::Encode;
 use test_utils::test_data::ias::*;
 
 fn assert_latest_worker_update<T: Config>(sender: &T::AccountId, shard: &ShardIdentifier) {

--- a/sidechain/src/tests.rs
+++ b/sidechain/src/tests.rs
@@ -16,10 +16,10 @@
 */
 
 use crate::{mock::*, Error, Event as SidechainEvent};
-use codec::Encode;
 use enclave_bridge_primitives::{ShardConfig, ShardIdentifier};
 use frame_support::{assert_err, assert_ok, dispatch::DispatchResultWithPostInfo};
 use pallet_teerex::Pallet as Teerex;
+use parity_scale_codec::Encode;
 use sidechain_primitives::SidechainBlockConfirmation;
 use sp_core::H256;
 use sp_keyring::AccountKeyring;

--- a/teeracle/Cargo.toml
+++ b/teeracle/Cargo.toml
@@ -67,6 +67,10 @@ runtime-benchmarks = [
 	"hex-literal",
 	"pallet-timestamp/runtime-benchmarks",
 	"test-utils",
+	"pallet-teerex/runtime-benchmarks"
 ]
 
-try-runtime = [ "frame-support/try-runtime" ]
+try-runtime = [
+	"frame-support/try-runtime", 
+	"pallet-teerex/try-runtime"
+]

--- a/teeracle/Cargo.toml
+++ b/teeracle/Cargo.toml
@@ -37,10 +37,10 @@ timestamp = { workspace = true, optional = true }
 
 [dev-dependencies]
 externalities = { workspace = true }
-frame-benchmarking = { workspace = true }
+frame-benchmarking = { workspace = true, features = ["std"] }
 hex-literal = { workspace = true }
 sp-keyring = { workspace = true }
-pallet-balances = { workspace = true }
+pallet-balances = { workspace = true, features = ["std"] }
 test-utils = { path = "../test-utils" }
 timestamp = { workspace = true }
 

--- a/teeracle/Cargo.toml
+++ b/teeracle/Cargo.toml
@@ -9,8 +9,8 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-parity-scale-codec = { workspace = true }
 log = { workspace = true }
+parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 
 # local
@@ -32,8 +32,8 @@ sp-std = { workspace = true }
 # benchmarking
 frame-benchmarking = { workspace = true, optional = true }
 hex-literal = { workspace = true, optional = true }
-test-utils = { path = "../test-utils", optional = true }
 pallet-timestamp = { workspace = true, optional = true }
+test-utils = { path = "../test-utils", optional = true }
 
 [dev-dependencies]
 externalities = { workspace = true }
@@ -46,31 +46,31 @@ pallet-timestamp = { workspace = true }
 
 
 [features]
-default = [ "std" ]
+default = ["std"]
 std = [
-	"frame-support/std",
-	"frame-system/std",
-	"log/std",
-	"pallet-teerex/std",
-	"parity-scale-codec/std",
-	"scale-info/std",
-	"sp-core/std",
-	"sp-io/std",
-	"sp-runtime/std",
-	"sp-std/std",
-	"substrate-fixed/std",
-	"teeracle-primitives/std",
-	"teerex-primitives/std",
+    "frame-support/std",
+    "frame-system/std",
+    "log/std",
+    "pallet-teerex/std",
+    "parity-scale-codec/std",
+    "scale-info/std",
+    "sp-core/std",
+    "sp-io/std",
+    "sp-runtime/std",
+    "sp-std/std",
+    "substrate-fixed/std",
+    "teeracle-primitives/std",
+    "teerex-primitives/std",
 ]
 runtime-benchmarks = [
-	"frame-benchmarking",
-	"hex-literal",
-	"pallet-timestamp/runtime-benchmarks",
-	"test-utils",
-	"pallet-teerex/runtime-benchmarks"
+    "frame-benchmarking",
+    "hex-literal",
+    "pallet-timestamp/runtime-benchmarks",
+    "test-utils",
+    "pallet-teerex/runtime-benchmarks",
 ]
 
 try-runtime = [
-	"frame-support/try-runtime", 
-	"pallet-teerex/try-runtime"
+    "frame-support/try-runtime",
+    "pallet-teerex/try-runtime",
 ]

--- a/teeracle/Cargo.toml
+++ b/teeracle/Cargo.toml
@@ -33,7 +33,7 @@ sp-std = { workspace = true }
 frame-benchmarking = { workspace = true, optional = true }
 hex-literal = { workspace = true, optional = true }
 test-utils = { path = "../test-utils", optional = true }
-timestamp = { workspace = true, optional = true }
+pallet-timestamp = { workspace = true, optional = true }
 
 [dev-dependencies]
 externalities = { workspace = true }
@@ -42,7 +42,7 @@ hex-literal = { workspace = true }
 sp-keyring = { workspace = true }
 pallet-balances = { workspace = true, features = ["std"] }
 test-utils = { path = "../test-utils" }
-timestamp = { workspace = true }
+pallet-timestamp = { workspace = true }
 
 
 [features]
@@ -66,7 +66,7 @@ runtime-benchmarks = [
     "frame-benchmarking",
     "hex-literal",
     "test-utils",
-    "timestamp/runtime-benchmarks",
+    "pallet-timestamp/runtime-benchmarks",
 ]
 
 try-runtime = ["frame-support/try-runtime"]

--- a/teeracle/Cargo.toml
+++ b/teeracle/Cargo.toml
@@ -46,27 +46,27 @@ pallet-timestamp = { workspace = true }
 
 
 [features]
-default = ["std"]
+default = [ "std" ]
 std = [
-    "parity-scale-codec/std",
-    "frame-support/std",
-    "frame-system/std",
-    "log/std",
-    "pallet-teerex/std",
-    "scale-info/std",
-    "sp-core/std",
-    "sp-io/std",
-    "sp-runtime/std",
-    "sp-std/std",
-    "substrate-fixed/std",
-    "teeracle-primitives/std",
-    "teerex-primitives/std",
+	"frame-support/std",
+	"frame-system/std",
+	"log/std",
+	"pallet-teerex/std",
+	"parity-scale-codec/std",
+	"scale-info/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-runtime/std",
+	"sp-std/std",
+	"substrate-fixed/std",
+	"teeracle-primitives/std",
+	"teerex-primitives/std",
 ]
 runtime-benchmarks = [
-    "frame-benchmarking",
-    "hex-literal",
-    "test-utils",
-    "pallet-timestamp/runtime-benchmarks",
+	"frame-benchmarking",
+	"hex-literal",
+	"pallet-timestamp/runtime-benchmarks",
+	"test-utils",
 ]
 
-try-runtime = ["frame-support/try-runtime"]
+try-runtime = [ "frame-support/try-runtime" ]

--- a/teeracle/Cargo.toml
+++ b/teeracle/Cargo.toml
@@ -9,9 +9,9 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-codec = { version = "3.6.1", default-features = false, features = ["derive"], package = "parity-scale-codec" }
-log = { version = "0.4.14", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+parity-scale-codec = { workspace = true }
+log = { workspace = true }
+scale-info = { workspace = true }
 
 # local
 pallet-teerex = { path = "../teerex", default-features = false }
@@ -22,33 +22,33 @@ teerex-primitives = { path = "../primitives/teerex", default-features = false }
 substrate-fixed = { tag = "v0.5.9", default-features = false, git = "https://github.com/encointer/substrate-fixed.git" }
 
 # substrate
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 # benchmarking
-frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-hex-literal = { version = "0.3.2", optional = true }
-test-utils = { path = "../test-utils", optional = true, default-features = false }
-timestamp = { package = "pallet-timestamp", default-features = false, optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+frame-benchmarking = { workspace = true, optional = true }
+hex-literal = { workspace = true, optional = true }
+test-utils = { path = "../test-utils", optional = true }
+timestamp = { workspace = true, optional = true }
 
 [dev-dependencies]
-externalities = { package = "sp-externalities", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-hex-literal = "0.3.2"
-sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+externalities = { workspace = true }
+frame-benchmarking = { workspace = true }
+hex-literal = { workspace = true }
+sp-keyring = { workspace = true }
+pallet-balances = { workspace = true }
 test-utils = { path = "../test-utils" }
-timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+timestamp = { workspace = true }
 
 
 [features]
 default = ["std"]
 std = [
-    "codec/std",
+    "parity-scale-codec/std",
     "frame-support/std",
     "frame-system/std",
     "log/std",

--- a/teeracle/src/benchmarking.rs
+++ b/teeracle/src/benchmarking.rs
@@ -38,7 +38,7 @@ use test_utils::{
 benchmarks! {
 	where_clause {  where T::AccountId: From<[u8; 32]>, T::Hash: From<[u8; 32]> }
 	update_exchange_rate {
-		timestamp::Pallet::<T>::set_timestamp(TEST4_SETUP.timestamp.checked_into().unwrap());
+		pallet_timestamp::Pallet::<T>::set_timestamp(TEST4_SETUP.timestamp.checked_into().unwrap());
 		let signer: T::AccountId = get_signer(TEST4_SETUP.signer_pub);
 		let trading_pair: TradingPairString =  "DOT/USD".into();
 		let rate = U32F32::from_num(43.65);
@@ -60,7 +60,7 @@ benchmarks! {
 	}
 
 	update_oracle {
-		timestamp::Pallet::<T>::set_timestamp(TEST4_SETUP.timestamp.checked_into().unwrap());
+		pallet_timestamp::Pallet::<T>::set_timestamp(TEST4_SETUP.timestamp.checked_into().unwrap());
 		let signer: T::AccountId = get_signer(TEST4_SETUP.signer_pub);
 		let oracle_name = OracleDataName::from("Test_Oracle_Name");
 		let data_source = DataSource::from("Test_Source_Name");

--- a/teeracle/src/mock.rs
+++ b/teeracle/src/mock.rs
@@ -49,7 +49,7 @@ frame_support::construct_runtime!(
 	{
 		System: frame_system,
 		Balances: pallet_balances,
-		Timestamp: timestamp,
+		Timestamp: pallet_timestamp,
 		Teerex: pallet_teerex,
 		Teeracle: pallet_teeracle,
 	}
@@ -112,7 +112,7 @@ parameter_types! {
 
 pub type Moment = u64;
 
-impl timestamp::Config for Test {
+impl pallet_timestamp::Config for Test {
 	type Moment = Moment;
 	type OnTimestampSet = ();
 	type MinimumPeriod = MinimumPeriod;

--- a/teerex/Cargo.toml
+++ b/teerex/Cargo.toml
@@ -42,8 +42,8 @@ hex-literal = { workspace = true }
 pallet-balances = { workspace = true, features = ["std"] }
 sp-keyring = { workspace = true }
 test-utils = { path = "../test-utils" }
-serde = { version = "1.0.171", features = ["derive"] }
-serde_json = { version = "1.0", features = ["alloc"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [features]
 default = ["std"]

--- a/teerex/Cargo.toml
+++ b/teerex/Cargo.toml
@@ -37,9 +37,9 @@ test-utils = { path = "../test-utils", optional = true }
 [dev-dependencies]
 env_logger = { workspace = true }
 externalities = { workspace = true }
-frame-benchmarking = { workspace = true }
+frame-benchmarking = { workspace = true, features = ["std"] }
 hex-literal = { workspace = true }
-pallet-balances = { workspace = true }
+pallet-balances = { workspace = true, features = ["std"] }
 sp-keyring = { workspace = true }
 test-utils = { path = "../test-utils" }
 serde = { version = "1.0.171", features = ["derive"] }

--- a/teerex/Cargo.toml
+++ b/teerex/Cargo.toml
@@ -9,39 +9,38 @@ license = "MS-RSL"
 edition = "2021"
 
 [dependencies]
-codec = { version = "3.6.1", default-features = false, features = ["derive"], package = "parity-scale-codec" }
-hex = { default-features = false, version = "0.4.3", features = ["alloc"] }
-log = { version = "0.4.14", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
-serde = { version = "1.0.171", features = ["derive"], optional = true }
-webpki = { git = "https://github.com/rustls/webpki", version = "=0.102.0-alpha.3", rev = "da923ed", package = "rustls-webpki", default-features = false, features = ["alloc", "ring"] }
+parity-scale-codec = { workspace = true }
+hex = { workspace = true }
+log = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true, optional = true }
+webpki = { workspace = true }
 
 # local
 sgx-verify = { path = "sgx-verify", default-features = false }
 teerex-primitives = { path = "../primitives/teerex", default-features = false }
 
 # substrate dependencies
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-timestamp = { package = "pallet-timestamp", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
+timestamp = { workspace = true }
 
 # benchmarking
-frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-hex-literal = { version = "0.3.2", optional = true }
-pallet-balances = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-test-utils = { path = "../test-utils", default-features = false, optional = true }
-
+frame-benchmarking = { workspace = true, optional = true }
+hex-literal = { workspace = true, optional = true }
+pallet-balances = { workspace = true, optional = true }
+test-utils = { path = "../test-utils", optional = true }
 [dev-dependencies]
-env_logger = "0.9.0"
-externalities = { package = "sp-externalities", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-hex-literal = "0.3.2"
-pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+env_logger = { workspace = true }
+externalities = { workspace = true }
+frame-benchmarking = { workspace = true }
+hex-literal = { workspace = true }
+pallet-balances = { workspace = true }
+sp-keyring = { workspace = true }
 test-utils = { path = "../test-utils" }
 serde = { version = "1.0.171", features = ["derive"] }
 serde_json = { version = "1.0", features = ["alloc"] }
@@ -49,7 +48,7 @@ serde_json = { version = "1.0", features = ["alloc"] }
 [features]
 default = ["std"]
 std = [
-    "codec/std",
+    "parity-scale-codec/std",
     "frame-support/std",
     "frame-system/std",
     "log/std",

--- a/teerex/Cargo.toml
+++ b/teerex/Cargo.toml
@@ -27,7 +27,7 @@ sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
-timestamp = { workspace = true }
+pallet-timestamp = { workspace = true }
 
 # benchmarking
 frame-benchmarking = { workspace = true, optional = true }
@@ -60,7 +60,7 @@ std = [
     "sp-runtime/std",
     "sp-std/std",
     "teerex-primitives/std",
-    "timestamp/std",
+    "pallet-timestamp/std",
     "webpki/std",
 ]
 runtime-benchmarks = [
@@ -68,7 +68,7 @@ runtime-benchmarks = [
     "hex-literal",
     "pallet-balances",
     "test-utils",
-    "timestamp/runtime-benchmarks",
+    "pallet-timestamp/runtime-benchmarks",
 ]
 
 try-runtime = ["frame-support/try-runtime"]

--- a/teerex/Cargo.toml
+++ b/teerex/Cargo.toml
@@ -34,6 +34,7 @@ frame-benchmarking = { workspace = true, optional = true }
 hex-literal = { workspace = true, optional = true }
 pallet-balances = { workspace = true, optional = true }
 test-utils = { path = "../test-utils", optional = true }
+
 [dev-dependencies]
 env_logger = { workspace = true }
 externalities = { workspace = true, features = ["std"] }
@@ -43,7 +44,7 @@ pallet-balances = { workspace = true, features = ["std"] }
 sp-keyring = { workspace = true }
 test-utils = { path = "../test-utils" }
 serde = { workspace = true, features = ["std"] }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["std"] }
 
 [features]
 default = [ "std" ]

--- a/teerex/Cargo.toml
+++ b/teerex/Cargo.toml
@@ -46,29 +46,29 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 [features]
-default = ["std"]
+default = [ "std" ]
 std = [
-    "parity-scale-codec/std",
-    "frame-support/std",
-    "frame-system/std",
-    "log/std",
-    "scale-info/std",
-    "serde",
-    "sgx-verify/std",
-    "sp-core/std",
-    "sp-io/std",
-    "sp-runtime/std",
-    "sp-std/std",
-    "teerex-primitives/std",
-    "pallet-timestamp/std",
-    "webpki/std",
+	"frame-support/std",
+	"frame-system/std",
+	"log/std",
+	"pallet-timestamp/std",
+	"parity-scale-codec/std",
+	"scale-info/std",
+	"serde",
+	"sgx-verify/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-runtime/std",
+	"sp-std/std",
+	"teerex-primitives/std",
+	"webpki/std",
 ]
 runtime-benchmarks = [
-    "frame-benchmarking",
-    "hex-literal",
-    "pallet-balances",
-    "test-utils",
-    "pallet-timestamp/runtime-benchmarks",
+	"frame-benchmarking",
+	"hex-literal",
+	"pallet-balances",
+	"pallet-timestamp/runtime-benchmarks",
+	"test-utils",
 ]
 
-try-runtime = ["frame-support/try-runtime"]
+try-runtime = [ "frame-support/try-runtime" ]

--- a/teerex/Cargo.toml
+++ b/teerex/Cargo.toml
@@ -9,9 +9,9 @@ license = "MS-RSL"
 edition = "2021"
 
 [dependencies]
-parity-scale-codec = { workspace = true }
 hex = { workspace = true }
 log = { workspace = true }
+parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 serde = { workspace = true, optional = true }
 webpki = { workspace = true }
@@ -23,11 +23,11 @@ teerex-primitives = { path = "../primitives/teerex", default-features = false }
 # substrate dependencies
 frame-support = { workspace = true }
 frame-system = { workspace = true }
+pallet-timestamp = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
-pallet-timestamp = { workspace = true }
 
 # benchmarking
 frame-benchmarking = { workspace = true, optional = true }
@@ -47,29 +47,29 @@ serde = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }
 
 [features]
-default = [ "std" ]
+default = ["std"]
 std = [
-	"frame-support/std",
-	"frame-system/std",
-	"log/std",
-	"pallet-timestamp/std",
-	"parity-scale-codec/std",
-	"scale-info/std",
-	"serde/std",
-	"sgx-verify/std",
-	"sp-core/std",
-	"sp-io/std",
-	"sp-runtime/std",
-	"sp-std/std",
-	"teerex-primitives/std",
-	"webpki/std",
+    "frame-support/std",
+    "frame-system/std",
+    "log/std",
+    "pallet-timestamp/std",
+    "parity-scale-codec/std",
+    "scale-info/std",
+    "serde/std",
+    "sgx-verify/std",
+    "sp-core/std",
+    "sp-io/std",
+    "sp-runtime/std",
+    "sp-std/std",
+    "teerex-primitives/std",
+    "webpki/std",
 ]
 runtime-benchmarks = [
-	"frame-benchmarking",
-	"hex-literal",
-	"pallet-balances",
-	"pallet-timestamp/runtime-benchmarks",
-	"test-utils",
+    "frame-benchmarking",
+    "hex-literal",
+    "pallet-balances",
+    "pallet-timestamp/runtime-benchmarks",
+    "test-utils",
 ]
 
-try-runtime = [ "frame-support/try-runtime" ]
+try-runtime = ["frame-support/try-runtime"]

--- a/teerex/Cargo.toml
+++ b/teerex/Cargo.toml
@@ -36,13 +36,13 @@ pallet-balances = { workspace = true, optional = true }
 test-utils = { path = "../test-utils", optional = true }
 [dev-dependencies]
 env_logger = { workspace = true }
-externalities = { workspace = true }
+externalities = { workspace = true, features = ["std"] }
 frame-benchmarking = { workspace = true, features = ["std"] }
 hex-literal = { workspace = true }
 pallet-balances = { workspace = true, features = ["std"] }
 sp-keyring = { workspace = true }
 test-utils = { path = "../test-utils" }
-serde = { workspace = true }
+serde = { workspace = true, features = ["std"] }
 serde_json = { workspace = true }
 
 [features]
@@ -54,7 +54,7 @@ std = [
 	"pallet-timestamp/std",
 	"parity-scale-codec/std",
 	"scale-info/std",
-	"serde",
+	"serde/std",
 	"sgx-verify/std",
 	"sp-core/std",
 	"sp-io/std",

--- a/teerex/sgx-verify/Cargo.toml
+++ b/teerex/sgx-verify/Cargo.toml
@@ -19,7 +19,7 @@ log = { workspace = true }
 ring = { workspace = true }
 scale-info = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["alloc"] }
 webpki = { workspace = true }
 x509-cert = { workspace = true }
 

--- a/teerex/sgx-verify/Cargo.toml
+++ b/teerex/sgx-verify/Cargo.toml
@@ -9,38 +9,38 @@ license = "GPL-3.0"
 edition = "2021"
 
 [dependencies]
-base64 = { version = "0.13", default-features = false, features = ["alloc"] }
-chrono = { version = "0.4", default-features = false, features = ["serde"] }
-codec = { version = "3.6.1", default-features = false, features = ["derive"], package = "parity-scale-codec" }
-der = { default-features = false, version = "0.6.0" }
-hex = { default-features = false, version = "0.4.3", features = ["alloc"] }
-hex-literal = { version = "0.3.2" }
-log = { version = "0.4.14", default-features = false }
-ring = { version = "0.16.20", default-features = false, features = ["alloc"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
-serde = { default-features = false, version = "1.0.171", features = ["derive"] }
-serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
-webpki = { git = "https://github.com/rustls/webpki", version = "=0.102.0-alpha.3", rev = "da923ed", package = "rustls-webpki", default-features = false, features = ["alloc", "ring"] }
-x509-cert = { default-features = false, version = "0.1.0", features = ["alloc"] }
+base64 = { workspace = true }
+chrono = { workspace = true }
+parity-scale-codec = { workspace = true }
+der = { workspace = true }
+hex = { workspace = true }
+hex-literal = { workspace = true }
+log = { workspace = true }
+ring = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+webpki = { workspace = true }
+x509-cert = { workspace = true }
 
 # local
 teerex-primitives = { path = "../../primitives/teerex", default-features = false }
 
 # substrate dependencies
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+frame-support = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-std = { workspace = true }
 
 [dev-dependencies]
-hex-literal = "0.3.4"
+hex-literal = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
     "base64/std",
     "chrono/std",
-    "codec/std",
+    "parity-scale-codec/std",
     "der/std",
     "hex/std",
     "log/std",

--- a/teerex/sgx-verify/Cargo.toml
+++ b/teerex/sgx-verify/Cargo.toml
@@ -11,11 +11,11 @@ edition = "2021"
 [dependencies]
 base64 = { workspace = true }
 chrono = { workspace = true }
-parity-scale-codec = { workspace = true }
 der = { workspace = true }
 hex = { workspace = true }
 hex-literal = { workspace = true }
 log = { workspace = true }
+parity-scale-codec = { workspace = true }
 ring = { workspace = true }
 scale-info = { workspace = true }
 serde = { workspace = true }
@@ -36,27 +36,27 @@ sp-std = { workspace = true }
 hex-literal = { workspace = true }
 
 [features]
-default = [ "std" ]
+default = ["std"]
 std = [
-	"base64/std",
-	"chrono/std",
-	"der/std",
-	# substrate
-	"frame-support/std",
-	"hex/std",
-	"log/std",
-	"parity-scale-codec/std",
-	"ring/std",
-	"scale-info/std",
-	"serde/std",
-	"serde_json/std",
-	"sp-core/std",
-	"sp-io/std",
-	"sp-std/std",
-	# local
-	"teerex-primitives/std",
-	"webpki/std",
-	"x509-cert/std",
+    "base64/std",
+    "chrono/std",
+    "der/std",
+    # substrate
+    "frame-support/std",
+    "hex/std",
+    "log/std",
+    "parity-scale-codec/std",
+    "ring/std",
+    "scale-info/std",
+    "serde/std",
+    "serde_json/std",
+    "sp-core/std",
+    "sp-io/std",
+    "sp-std/std",
+    # local
+    "teerex-primitives/std",
+    "webpki/std",
+    "x509-cert/std",
 ]
 # Export ias/dcap data when we want to use them
 # in tests/benchmarks in the pallets.

--- a/teerex/sgx-verify/Cargo.toml
+++ b/teerex/sgx-verify/Cargo.toml
@@ -36,27 +36,27 @@ sp-std = { workspace = true }
 hex-literal = { workspace = true }
 
 [features]
-default = ["std"]
+default = [ "std" ]
 std = [
-    "base64/std",
-    "chrono/std",
-    "parity-scale-codec/std",
-    "der/std",
-    "hex/std",
-    "log/std",
-    "ring/std",
-    "scale-info/std",
-    "serde/std",
-    "serde_json/std",
-    "webpki/std",
-    "x509-cert/std",
-    # local
-    "teerex-primitives/std",
-    # substrate
-    "frame-support/std",
-    "sp-core/std",
-    "sp-io/std",
-    "sp-std/std",
+	"base64/std",
+	"chrono/std",
+	"der/std",
+	# substrate
+	"frame-support/std",
+	"hex/std",
+	"log/std",
+	"parity-scale-codec/std",
+	"ring/std",
+	"scale-info/std",
+	"serde/std",
+	"serde_json/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-std/std",
+	# local
+	"teerex-primitives/std",
+	"webpki/std",
+	"x509-cert/std",
 ]
 # Export ias/dcap data when we want to use them
 # in tests/benchmarks in the pallets.

--- a/teerex/sgx-verify/fuzz/Cargo.toml
+++ b/teerex/sgx-verify/fuzz/Cargo.toml
@@ -9,8 +9,8 @@ cargo-fuzz = true
 
 [dependencies]
 base64 = { version = "0.13", default-features = false, features = ["alloc"] }
-codec = { version = "3.6.1", default-features = false, features = ["derive"], package = "parity-scale-codec" }
-hex-literal = "0.3.4"
+parity-scale-codec = { workspace = true }
+hex-literal = { workspace = true }
 libfuzzer-sys = "0.4"
 serde_json = { version = "1.0" }
 webpki = { git = "https://github.com/rustls/webpki", version = "=0.102.0-alpha.3", rev = "da923ed", package = "rustls-webpki", default-features = false, features = ["alloc", "ring"] }

--- a/teerex/sgx-verify/fuzz/Cargo.toml
+++ b/teerex/sgx-verify/fuzz/Cargo.toml
@@ -9,8 +9,8 @@ cargo-fuzz = true
 
 [dependencies]
 base64 = { version = "0.13", default-features = false, features = ["alloc"] }
-parity-scale-codec = { workspace = true }
-hex-literal = { workspace = true }
+codec = { version = "3.6.1", default-features = false, features = ["derive"], package = "parity-scale-codec" }
+hex-literal = "0.3.4"
 libfuzzer-sys = "0.4"
 serde_json = { version = "1.0" }
 webpki = { git = "https://github.com/rustls/webpki", version = "=0.102.0-alpha.3", rev = "da923ed", package = "rustls-webpki", default-features = false, features = ["alloc", "ring"] }

--- a/teerex/sgx-verify/fuzz/fuzz_targets/decode_quote.rs
+++ b/teerex/sgx-verify/fuzz/fuzz_targets/decode_quote.rs
@@ -1,12 +1,12 @@
 #![no_main]
 
-use codec::Decode;
 use libfuzzer_sys::fuzz_target;
+use parity_scale_codec::Decode;
 use sgx_verify::DcapQuote;
 
 fuzz_target!(|data: &[u8]| {
 	let mut copy = data;
-	let _quote: Result<DcapQuote, codec::Error> = Decode::decode(&mut copy);
+	let _quote: Result<DcapQuote, parity_scale_codec::Error> = Decode::decode(&mut copy);
 
 	// This assert is commented out because the fuzzer manages to find a "valid" quote that can
 	// at least be decoded into memory. We would need additional verification steps (for example signature)

--- a/teerex/sgx-verify/src/lib.rs
+++ b/teerex/sgx-verify/src/lib.rs
@@ -38,10 +38,10 @@ use crate::{
 };
 use alloc::string::String;
 use chrono::DateTime;
-use codec::{Decode, Encode, Input};
 use core::time::Duration;
 use der::asn1::ObjectIdentifier;
 use frame_support::{ensure, traits::Len};
+use parity_scale_codec::{Decode, Encode, Input};
 use ring::signature::{self};
 use scale_info::TypeInfo;
 use serde_json::Value;
@@ -173,7 +173,7 @@ pub struct QeAuthenticationData {
 }
 
 impl Decode for QeAuthenticationData {
-	fn decode<I: Input>(input: &mut I) -> Result<Self, codec::Error> {
+	fn decode<I: Input>(input: &mut I) -> Result<Self, parity_scale_codec::Error> {
 		let mut size_buf: [u8; 2] = [0; 2];
 		input.read(&mut size_buf)?;
 		let size = u16::from_le_bytes(size_buf);
@@ -194,7 +194,7 @@ pub struct QeCertificationData {
 }
 
 impl Decode for QeCertificationData {
-	fn decode<I: Input>(input: &mut I) -> Result<Self, codec::Error> {
+	fn decode<I: Input>(input: &mut I) -> Result<Self, parity_scale_codec::Error> {
 		let mut certification_data_type_buf: [u8; 2] = [0; 2];
 		input.read(&mut certification_data_type_buf)?;
 		let certification_data_type = u16::from_le_bytes(certification_data_type_buf);
@@ -204,7 +204,7 @@ impl Decode for QeCertificationData {
 		let size = u32::from_le_bytes(size_buf);
 		// This is an arbitrary limit to prevent out of memory issues. Intel does not specify a max value
 		if size > 65_000 {
-			return Result::Err(codec::Error::from(
+			return Result::Err(parity_scale_codec::Error::from(
 				"Certification data too long. Max 65000 bytes are allowed",
 			))
 		}

--- a/teerex/sgx-verify/src/tests.rs
+++ b/teerex/sgx-verify/src/tests.rs
@@ -26,9 +26,9 @@ use crate::{
 		},
 	},
 };
-use codec::Decode;
 use frame_support::assert_err;
 use hex_literal::hex;
+use parity_scale_codec::Decode;
 
 #[test]
 fn verify_ias_report_should_work() {

--- a/teerex/src/benchmarking.rs
+++ b/teerex/src/benchmarking.rs
@@ -50,7 +50,7 @@ benchmarks! {
 	// Benchmark `register_sgx_enclave` with the worst possible conditions (DCAP sovereign is more involved than Ias or proxied DCAP):
 	// * dcap registration succeeds with `proxied: false`
 	register_sgx_enclave {
-		timestamp::Pallet::<T>::set_timestamp(TEST_VALID_COLLATERAL_TIMESTAMP.checked_into().unwrap());
+		pallet_timestamp::Pallet::<T>::set_timestamp(TEST_VALID_COLLATERAL_TIMESTAMP.checked_into().unwrap());
 		let signer: T::AccountId = get_signer(&TEST1_DCAP_QUOTE_SIGNER);
 
 		register_test_quoting_enclave::<T>(signer.clone());
@@ -66,7 +66,7 @@ benchmarks! {
 	// Benchmark `register_quoting_enclave` with the worst possible conditions:
 	// * quoting enclave registration succeeds
 	register_quoting_enclave {
-		timestamp::Pallet::<T>::set_timestamp(TEST_VALID_COLLATERAL_TIMESTAMP.checked_into().unwrap());
+		pallet_timestamp::Pallet::<T>::set_timestamp(TEST_VALID_COLLATERAL_TIMESTAMP.checked_into().unwrap());
 		let signer: T::AccountId = get_signer(&TEST1_DCAP_QUOTE_SIGNER);
 
 	}: _(RawOrigin::Signed(signer), QUOTING_ENCLAVE.to_vec(), QUOTING_ENCLAVE_SIGNATURE.to_vec(), QE_IDENTITY_ISSUER_CHAIN.to_vec())
@@ -78,7 +78,7 @@ benchmarks! {
 	// Benchmark `register_tcb_info` with the worst possible conditions:
 	// * tcb registration succeeds
 	register_tcb_info {
-		timestamp::Pallet::<T>::set_timestamp(TEST_VALID_COLLATERAL_TIMESTAMP.checked_into().unwrap());
+		pallet_timestamp::Pallet::<T>::set_timestamp(TEST_VALID_COLLATERAL_TIMESTAMP.checked_into().unwrap());
 		let signer: T::AccountId = get_signer(&TEST1_DCAP_QUOTE_SIGNER);
 		register_test_quoting_enclave::<T>(signer.clone());
 
@@ -95,7 +95,7 @@ benchmarks! {
 		let enclave_count = 3;
 		let accounts: Vec<T::AccountId> = generate_accounts::<T>(enclave_count);
 		add_sovereign_enclaves_to_registry::<T>(&accounts);
-		timestamp::Pallet::<T>::set_timestamp((TEST4_TIMESTAMP + MAX_SILENCE_TIME + 1).checked_into().unwrap());
+		pallet_timestamp::Pallet::<T>::set_timestamp((TEST4_TIMESTAMP + MAX_SILENCE_TIME + 1).checked_into().unwrap());
 
 	}: _(RawOrigin::Signed(accounts[0].clone()), accounts[0].clone())
 	verify {
@@ -111,7 +111,7 @@ benchmarks! {
 		add_proxied_enclaves_to_registry::<T>(&accounts);
 		let (key0, value0) = <ProxiedEnclaves<T>>::iter()
 		.collect::<Vec<(EnclaveInstanceAddress<T::AccountId>, MultiEnclave<Vec<u8>>)>>()[0].clone();
-		timestamp::Pallet::<T>::set_timestamp((TEST4_TIMESTAMP + MAX_SILENCE_TIME + 1).checked_into().unwrap());
+		pallet_timestamp::Pallet::<T>::set_timestamp((TEST4_TIMESTAMP + MAX_SILENCE_TIME + 1).checked_into().unwrap());
 
 	}: _(RawOrigin::Signed(accounts[0].clone()), key0.clone())
 	verify {

--- a/teerex/src/lib.rs
+++ b/teerex/src/lib.rs
@@ -61,7 +61,7 @@ pub mod pallet {
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
 
 	#[pallet::config]
-	pub trait Config: frame_system::Config + timestamp::Config {
+	pub trait Config: frame_system::Config + pallet_timestamp::Config {
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
 		#[pallet::constant]
@@ -340,7 +340,7 @@ pub mod pallet {
 					enclave
 				},
 				SgxAttestationMethod::Dcap { proxied } => {
-					let verification_time = <timestamp::Pallet<T>>::get();
+					let verification_time = <pallet_timestamp::Pallet<T>>::get();
 
 					let qe = <SgxQuotingEnclaveRegistry<T>>::get();
 					let (fmspc, tcb_info, report) = sgx_verify::verify_dcap_quote(
@@ -409,7 +409,7 @@ pub mod pallet {
 						// insert mrenclave if the ra_report represents one, otherwise insert default
 						<MrEnclave>::decode(&mut proof.as_slice()).unwrap_or_default(),
 						MrSigner::default(),
-						<timestamp::Pallet<T>>::get().saturated_into(),
+						<pallet_timestamp::Pallet<T>>::get().saturated_into(),
 						SgxBuildMode::default(),
 						SgxStatus::Invalid,
 					)
@@ -455,7 +455,7 @@ pub mod pallet {
 			ensure_signed(origin)?;
 			let enclave = Self::sovereign_enclaves(&enclave_signer)
 				.ok_or(Error::<T>::EnclaveIsNotRegistered)?;
-			let now = <timestamp::Pallet<T>>::get();
+			let now = <pallet_timestamp::Pallet<T>>::get();
 			let oldest_acceptable_attestation_time = now
 				.saturating_sub(T::MaxAttestationRenewalPeriod::get())
 				.saturated_into::<u64>();
@@ -479,7 +479,7 @@ pub mod pallet {
 			ensure_signed(origin)?;
 			let enclave =
 				Self::proxied_enclaves(&address).ok_or(Error::<T>::EnclaveIsNotRegistered)?;
-			let now = <timestamp::Pallet<T>>::get();
+			let now = <pallet_timestamp::Pallet<T>>::get();
 			let oldest_acceptable_attestation_time = now
 				.saturating_sub(T::MaxAttestationRenewalPeriod::get())
 				.saturated_into::<u64>();
@@ -587,7 +587,7 @@ impl<T: Config> Pallet<T> {
 		signature: Vec<u8>,
 		certificate_chain: Vec<u8>,
 	) -> Result<SgxQuotingEnclave, DispatchErrorWithPostInfo> {
-		let verification_time: u64 = <timestamp::Pallet<T>>::get().saturated_into();
+		let verification_time: u64 = <pallet_timestamp::Pallet<T>>::get().saturated_into();
 		let certs = extract_certs(&certificate_chain);
 		ensure!(certs.len() >= 2, Error::<T>::CertificateChainIsTooShort);
 		let intermediate_slices: Vec<webpki::types::CertificateDer> =
@@ -614,7 +614,7 @@ impl<T: Config> Pallet<T> {
 		signature: Vec<u8>,
 		certificate_chain: Vec<u8>,
 	) -> Result<(Fmspc, SgxTcbInfoOnChain), DispatchErrorWithPostInfo> {
-		let verification_time: u64 = <timestamp::Pallet<T>>::get().saturated_into();
+		let verification_time: u64 = <pallet_timestamp::Pallet<T>>::get().saturated_into();
 		let certs = extract_certs(&certificate_chain);
 		ensure!(certs.len() >= 2, Error::<T>::CertificateChainIsTooShort);
 		log::trace!(target: TEEREX, "Self::verify_tcb_info, certs len is >= 2.");
@@ -638,7 +638,7 @@ impl<T: Config> Pallet<T> {
 	fn ensure_timestamp_within_24_hours(report_timestamp: u64) -> DispatchResultWithPostInfo {
 		use sp_runtime::traits::CheckedSub;
 
-		let elapsed_time = <timestamp::Pallet<T>>::get()
+		let elapsed_time = <pallet_timestamp::Pallet<T>>::get()
 			.checked_sub(&T::Moment::saturated_from(report_timestamp))
 			.ok_or("Underflow while calculating elapsed time since report creation")?;
 

--- a/teerex/src/lib.rs
+++ b/teerex/src/lib.rs
@@ -17,7 +17,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::Encode;
 use frame_support::{
 	dispatch::{DispatchErrorWithPostInfo, DispatchResultWithPostInfo},
 	ensure,
@@ -25,6 +24,7 @@ use frame_support::{
 	traits::Get,
 };
 use frame_system::{self, ensure_signed};
+use parity_scale_codec::Encode;
 use sgx_verify::{
 	deserialize_enclave_identity, deserialize_tcb_info, extract_certs, verify_certificate_chain,
 };

--- a/teerex/src/mock.rs
+++ b/teerex/src/mock.rs
@@ -51,7 +51,7 @@ frame_support::construct_runtime!(
 	{
 		System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-		Timestamp: timestamp::{Pallet, Call, Storage, Inherent},
+		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 		Teerex: pallet_teerex::{Pallet, Call, Storage, Event<T>},
 	}
 );
@@ -113,7 +113,7 @@ parameter_types! {
 
 pub type Moment = u64;
 
-impl timestamp::Config for Test {
+impl pallet_timestamp::Config for Test {
 	type Moment = Moment;
 	type OnTimestampSet = ();
 	type MinimumPeriod = MinimumPeriod;
@@ -178,5 +178,5 @@ pub fn new_test_production_ext() -> sp_io::TestExternalities {
 
 /// Helper method for the OnTimestampSet to be called
 pub fn set_timestamp(t: u64) {
-	let _ = timestamp::Pallet::<Test>::set(RuntimeOrigin::none(), t);
+	let _ = pallet_timestamp::Pallet::<Test>::set(RuntimeOrigin::none(), t);
 }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -15,5 +15,5 @@ sgx-verify = { default-features = false, features = ["test-data"], path = "../te
 teerex-primitives = { default-features = false, path = "../primitives/teerex" }
 
 [features]
-default = [ 'std' ]
-std = [ "log/std", "sgx-verify/std", "teerex-primitives/std" ]
+default = ['std']
+std = ["log/std", "sgx-verify/std", "teerex-primitives/std"]

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-log = { version = "0.4.14", default-features = false }
+log = { workspace = true }
 
 sgx-verify = { default-features = false, features = ["test-data"], path = "../teerex/sgx-verify" }
 teerex-primitives = { default-features = false, path = "../primitives/teerex" }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -15,9 +15,5 @@ sgx-verify = { default-features = false, features = ["test-data"], path = "../te
 teerex-primitives = { default-features = false, path = "../primitives/teerex" }
 
 [features]
-default = ['std']
-std = [
-    "log/std",
-    "sgx-verify/std",
-    "teerex-primitives/std",
-]
+default = [ 'std' ]
+std = [ "log/std", "sgx-verify/std", "teerex-primitives/std" ]

--- a/xcm-transactor/Cargo.toml
+++ b/xcm-transactor/Cargo.toml
@@ -45,21 +45,21 @@ sp-keyring = { workspace = true }
 
 
 [features]
-default = ["std"]
+default = [ "std" ]
 std = [
-    "parity-scale-codec/std",
-    "cumulus-primitives-core/std",
-    "frame-support/std",
-    "frame-system/std",
-    "log/std",
-    "scale-info/std",
-    "sp-core/std",
-    "sp-io/std",
-    "sp-runtime/std",
-    "sp-std/std",
-    "xcm-transactor-primitives/std",
-    "xcm/std",
+	"cumulus-primitives-core/std",
+	"frame-support/std",
+	"frame-system/std",
+	"log/std",
+	"parity-scale-codec/std",
+	"scale-info/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-runtime/std",
+	"sp-std/std",
+	"xcm-transactor-primitives/std",
+	"xcm/std",
 ]
 runtime-benchmarks = []
 
-try-runtime = ["frame-support/try-runtime"]
+try-runtime = [ "frame-support/try-runtime" ]

--- a/xcm-transactor/Cargo.toml
+++ b/xcm-transactor/Cargo.toml
@@ -9,20 +9,20 @@ license = "(GPL-3.0-only)"
 edition = "2021"
 
 [dependencies]
-codec = { version = "3.6.1", default-features = false, features = ["derive"], package = "parity-scale-codec" }
-log = { version = "0.4.14", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+parity-scale-codec = { workspace = true }
+log = { workspace = true }
+scale-info = { workspace = true }
 
 # Local
 xcm-transactor-primitives = { default-features = false, path = "../primitives/xcm-transactor", features = ["dot", "ksm"] }
 
 # substrate
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 # xcm/polkadot
 xcm = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
@@ -31,12 +31,12 @@ xcm = { default-features = false, git = "https://github.com/paritytech/polkadot"
 cumulus-primitives-core = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
 
 [dev-dependencies]
-externalities = { package = "sp-externalities", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-hex-literal = "0.3.2"
-pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+externalities = { workspace = true }
+frame-benchmarking = { workspace = true }
+hex-literal = { workspace = true }
+pallet-balances = { workspace = true }
 test-utils = { path = "../test-utils" }
-sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+sp-keyring = { workspace = true }
 
 # Re-introduce subxt whe we need it, maintaining it is a pain.
 # Remove unnecessary wasm stuff by disabling default features, also it lead
@@ -47,7 +47,7 @@ sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "po
 [features]
 default = ["std"]
 std = [
-    "codec/std",
+    "parity-scale-codec/std",
     "cumulus-primitives-core/std",
     "frame-support/std",
     "frame-system/std",

--- a/xcm-transactor/Cargo.toml
+++ b/xcm-transactor/Cargo.toml
@@ -9,8 +9,8 @@ license = "(GPL-3.0-only)"
 edition = "2021"
 
 [dependencies]
-parity-scale-codec = { workspace = true }
 log = { workspace = true }
+parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 
 # Local
@@ -45,21 +45,21 @@ sp-keyring = { workspace = true }
 
 
 [features]
-default = [ "std" ]
+default = ["std"]
 std = [
-	"cumulus-primitives-core/std",
-	"frame-support/std",
-	"frame-system/std",
-	"log/std",
-	"parity-scale-codec/std",
-	"scale-info/std",
-	"sp-core/std",
-	"sp-io/std",
-	"sp-runtime/std",
-	"sp-std/std",
-	"xcm-transactor-primitives/std",
-	"xcm/std",
+    "cumulus-primitives-core/std",
+    "frame-support/std",
+    "frame-system/std",
+    "log/std",
+    "parity-scale-codec/std",
+    "scale-info/std",
+    "sp-core/std",
+    "sp-io/std",
+    "sp-runtime/std",
+    "sp-std/std",
+    "xcm-transactor-primitives/std",
+    "xcm/std",
 ]
 runtime-benchmarks = []
 
-try-runtime = [ "frame-support/try-runtime" ]
+try-runtime = ["frame-support/try-runtime"]

--- a/xcm-transactor/src/tests.rs
+++ b/xcm-transactor/src/tests.rs
@@ -16,9 +16,9 @@
 */
 
 use crate::{mock::*, Config, Error};
-use codec::{Decode, Encode};
 use cumulus_primitives_core::ParaId;
 use frame_support::{assert_noop, assert_ok};
+use parity_scale_codec::{Decode, Encode};
 use sp_keyring::AccountKeyring;
 use xcm_transactor_primitives::*;
 


### PR DESCRIPTION
before migrating to polkadot 1.3.0 and crates.io, move all dependency definitions to workspace toml to remove redundancy and simplify future upgrades

functionally, this PR is a noop