### PR TITLE
fixing collator node build benchmark feature propagation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,7 +993,7 @@ name = "enclave-bridge-primitives"
 version = "0.1.0"
 dependencies = [
  "common-primitives",
- "hex-literal 0.3.4",
+ "hex-literal",
  "log",
  "parity-scale-codec",
  "scale-info",
@@ -1490,12 +1490,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hex-literal"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hex-literal"
@@ -2110,7 +2104,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "hex-literal 0.3.4",
+ "hex-literal",
  "libsecp256k1",
  "pallet-balances",
  "pallet-vesting",
@@ -2135,7 +2129,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "hex-literal 0.3.4",
+ "hex-literal",
  "log",
  "pallet-balances",
  "pallet-teerex",
@@ -2181,7 +2175,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "hex-literal 0.3.4",
+ "hex-literal",
  "log",
  "pallet-balances",
  "pallet-enclave-bridge",
@@ -2208,7 +2202,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "hex-literal 0.3.4",
+ "hex-literal",
  "log",
  "pallet-balances",
  "pallet-teerex",
@@ -2236,7 +2230,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex",
- "hex-literal 0.3.4",
+ "hex-literal",
  "log",
  "pallet-balances",
  "pallet-timestamp",
@@ -2301,7 +2295,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "hex-literal 0.3.4",
+ "hex-literal",
  "log",
  "pallet-balances",
  "parity-scale-codec",
@@ -2469,7 +2463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee4508ff6b035edc08c54bb61238500179963f6f1eb8266dce6a5625509124bc"
 dependencies = [
  "bitvec",
- "hex-literal 0.4.1",
+ "hex-literal",
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-parachain-primitives",
@@ -3018,7 +3012,7 @@ dependencies = [
  "der 0.6.1",
  "frame-support",
  "hex",
- "hex-literal 0.3.4",
+ "hex-literal",
  "log",
  "parity-scale-codec",
  "ring",
@@ -3834,7 +3828,7 @@ version = "0.1.0"
 dependencies = [
  "common-primitives",
  "derive_more",
- "hex-literal 0.3.4",
+ "hex-literal",
  "log",
  "parity-scale-codec",
  "scale-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ chrono = { version = "0.4", default-features = false, features = ["serde"] }
 derive_more = "0.99.16"
 env_logger = "0.9.0"
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
-hex-literal = "0.3.3"
+hex-literal = "0.4.1"
 log = { version = "0.4.20", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
 serde = { version = "1.0.188", default-features = false, features = ["alloc", "derive"] }

--- a/claims/Cargo.toml
+++ b/claims/Cargo.toml
@@ -37,6 +37,7 @@ default = ["std"]
 
 std = [
     "claims-primitives/std",
+    "frame-benchmarking?/std",
     "frame-support/std",
     "frame-system/std",
     "pallet-balances/std",
@@ -50,7 +51,7 @@ std = [
     "sp-std/std",
 ]
 runtime-benchmarks = [
-    "frame-benchmarking",
+    "frame-benchmarking/runtime-benchmarks",
     "frame-support/runtime-benchmarks",
     "frame-system/runtime-benchmarks",
     "libsecp256k1/hmac",

--- a/enclave-bridge/Cargo.toml
+++ b/enclave-bridge/Cargo.toml
@@ -32,7 +32,7 @@ sp-std = { workspace = true }
 frame-benchmarking = { workspace = true, optional = true }
 hex-literal = { workspace = true, optional = true }
 pallet-balances = { workspace = true, optional = true }
-test-utils = { path = "../test-utils", optional = true }
+test-utils = { default-features = false, path = "../test-utils", optional = true }
 
 [dev-dependencies]
 env_logger = { workspace = true }

--- a/enclave-bridge/Cargo.toml
+++ b/enclave-bridge/Cargo.toml
@@ -47,6 +47,7 @@ test-utils = { path = "../test-utils" }
 default = ["std"]
 std = [
     "enclave-bridge-primitives/std",
+    "frame-benchmarking?/std",
     "frame-support/std",
     "frame-system/std",
     "log/std",
@@ -62,7 +63,7 @@ std = [
     "teerex-primitives/std",
 ]
 runtime-benchmarks = [
-    "frame-benchmarking",
+    "frame-benchmarking/runtime-benchmarks",
     "hex-literal",
     "pallet-balances",
     "pallet-timestamp/runtime-benchmarks",

--- a/sidechain/Cargo.toml
+++ b/sidechain/Cargo.toml
@@ -34,7 +34,7 @@ frame-benchmarking = { workspace = true, optional = true }
 hex-literal = { workspace = true, optional = true }
 pallet-balances = { workspace = true, optional = true }
 teerex-primitives = { path = "../primitives/teerex", default-features = false }
-test-utils = { path = "../test-utils", optional = true }
+test-utils = { default-features = false, path = "../test-utils", optional = true }
 
 [dev-dependencies]
 env_logger = { workspace = true }

--- a/sidechain/Cargo.toml
+++ b/sidechain/Cargo.toml
@@ -49,6 +49,7 @@ test-utils = { path = "../test-utils" }
 default = ["std"]
 std = [
     "enclave-bridge-primitives/std",
+    "frame-benchmarking?/std",
     "frame-support/std",
     "frame-system/std",
     "log/std",
@@ -66,7 +67,7 @@ std = [
     "teerex-primitives/std",
 ]
 runtime-benchmarks = [
-    "frame-benchmarking",
+    "frame-benchmarking/runtime-benchmarks",
     "hex-literal",
     "pallet-balances",
     "pallet-timestamp/runtime-benchmarks",

--- a/teeracle/Cargo.toml
+++ b/teeracle/Cargo.toml
@@ -33,7 +33,7 @@ sp-std = { workspace = true }
 frame-benchmarking = { workspace = true, optional = true }
 hex-literal = { workspace = true, optional = true }
 pallet-timestamp = { workspace = true, optional = true }
-test-utils = { path = "../test-utils", optional = true }
+test-utils = { default-features = false, path = "../test-utils", optional = true }
 
 [dev-dependencies]
 sp-externalities = { workspace = true }

--- a/teeracle/Cargo.toml
+++ b/teeracle/Cargo.toml
@@ -48,6 +48,7 @@ pallet-timestamp = { workspace = true }
 [features]
 default = ["std"]
 std = [
+    "frame-benchmarking?/std",
     "frame-support/std",
     "frame-system/std",
     "log/std",
@@ -63,7 +64,7 @@ std = [
     "teerex-primitives/std",
 ]
 runtime-benchmarks = [
-    "frame-benchmarking",
+    "frame-benchmarking/runtime-benchmarks",
     "hex-literal",
     "pallet-timestamp/runtime-benchmarks",
     "test-utils",

--- a/teerex/Cargo.toml
+++ b/teerex/Cargo.toml
@@ -33,7 +33,7 @@ sp-std = { workspace = true }
 frame-benchmarking = { workspace = true, optional = true }
 hex-literal = { workspace = true, optional = true }
 pallet-balances = { workspace = true, optional = true }
-test-utils = { path = "../test-utils", optional = true }
+test-utils = { default-features = false, path = "../test-utils", optional = true }
 
 [dev-dependencies]
 env_logger = { workspace = true }

--- a/teerex/Cargo.toml
+++ b/teerex/Cargo.toml
@@ -49,6 +49,7 @@ serde_json = { workspace = true, features = ["std"] }
 [features]
 default = ["std"]
 std = [
+    "frame-benchmarking?/std",
     "frame-support/std",
     "frame-system/std",
     "log/std",
@@ -65,7 +66,7 @@ std = [
     "webpki/std",
 ]
 runtime-benchmarks = [
-    "frame-benchmarking",
+    "frame-benchmarking/runtime-benchmarks",
     "hex-literal",
     "pallet-balances",
     "pallet-timestamp/runtime-benchmarks",

--- a/xcm-transactor/Cargo.toml
+++ b/xcm-transactor/Cargo.toml
@@ -17,6 +17,7 @@ scale-info = { workspace = true }
 xcm-transactor-primitives = { default-features = false, path = "../primitives/xcm-transactor", features = ["dot", "ksm"] }
 
 # substrate
+frame-benchmarking = { workspace = true, optional = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 sp-core = { workspace = true }
@@ -48,6 +49,7 @@ sp-keyring = { workspace = true }
 default = ["std"]
 std = [
     "cumulus-primitives-core/std",
+    "frame-benchmarking?/std",
     "frame-support/std",
     "frame-system/std",
     "log/std",
@@ -60,6 +62,6 @@ std = [
     "xcm-transactor-primitives/std",
     "staging-xcm/std",
 ]
-runtime-benchmarks = []
+runtime-benchmarks = ["frame-benchmarking/runtime-benchmarks"]
 
 try-runtime = ["frame-support/try-runtime"]


### PR DESCRIPTION
we had a std leak in test-utils dependency when enabling runtime-benchmarks
along the way of debugging, I streamlined more feature propagation similar to parachain template