### PR TITLE
Add zepter config and add it to the CI

### DIFF
--- a/.cargo/zepter.yaml
+++ b/.cargo/zepter.yaml
@@ -1,0 +1,39 @@
+version:
+  format: 1
+  # Minimum version of the binary that is expected to work. This is just for printing a nice error
+  # message when someone tries to use an older version.
+  binary: 0.13.2
+
+# The examples in this file assume crate `A` to have a dependency on crate `B`.
+workflows:
+  check:
+    - [
+      'lint',
+      # Check that `A` activates the features of `B`.
+      'propagate-feature',
+      # These are the features to check:
+      '--features=try-runtime,runtime-benchmarks,std',
+      # Do not try to add a new section into `[features]` of `A` only because `B` expose that feature. There are edge-cases where this is still needed, but we can add them manually.
+      '--left-side-feature-missing=ignore',
+      # Ignore the case that `A` it outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.
+      '--left-side-outside-workspace=ignore',
+      # Some features imply that they activate a specific dependency as non-optional. Otherwise the default behaviour with a `?` is used.
+      '--feature-enables-dep=try-runtime:frame-try-runtime,runtime-benchmarks:frame-benchmarking',
+      # Auxillary flags:
+      '--offline',
+      '--locked',
+      '--show-path',
+      '--quiet',
+    ]
+  # Same as `check`, but with the `--fix` flag.
+  default:
+    - [ $check.0, '--fix' ]
+
+# Will be displayed when any workflow fails:
+help:
+  text: |
+    This repo uses the Zepter CLI to detect abnormalities in the feature configuration.
+    It looks like one more more checks failed; please check the console output. You can try to automatically address them by running `zepter`.
+    Otherwise please ask directly in the Merge Request, GitHub Discussions or on Matrix Chat, thank you.
+  links:
+    - "https://github.com/ggwpez/zepter"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,28 @@ jobs:
           name: license
           path: license.html
 
+  cargo-zepter:
+    name: Cargo Zepter
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install stable Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Install Zepter
+        run: cargo install --locked -q zepter && zepter --version
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Don't clone historic commits.
+
+      - name: Check features
+        run: zepter run check
+
   cargo-toml-fmt:
     runs-on: ubuntu-latest
     container: "tamasfe/taplo:0.7.0-alpine"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2634,7 +2634,7 @@ dependencies = [
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
- "rand_chacha",
+ "rand_chacha 0.2.2",
  "scale-info",
  "serde",
  "sp-application-crypto",
@@ -3149,7 +3149,7 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-runtime-metrics",
  "rand",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rustc-hex",
  "scale-info",
  "serde",
@@ -3325,8 +3325,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -5098,7 +5108,7 @@ dependencies = [
  "constcat",
  "digest 0.10.7",
  "rand",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sha2 0.10.8",
  "sha3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2634,6 +2634,7 @@ dependencies = [
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
+ "rand_chacha",
  "scale-info",
  "serde",
  "sp-application-crypto",
@@ -3068,6 +3069,7 @@ dependencies = [
  "log",
  "pallet-asset-rate",
  "pallet-authorship",
+ "pallet-babe",
  "pallet-balances",
  "pallet-broker",
  "pallet-election-provider-multi-phase",
@@ -3164,6 +3166,7 @@ dependencies = [
  "sp-std",
  "staging-xcm",
  "staging-xcm-executor",
+ "static_assertions",
 ]
 
 [[package]]

--- a/asset-registry/Cargo.toml
+++ b/asset-registry/Cargo.toml
@@ -65,11 +65,35 @@ std = [
     "staging-xcm-executor/std",
     "staging-xcm/std",
     "xcm-primitives/std",
+    "sp-core/std",
+    "sp-io/std",
 ]
 runtime-benchmarks = [
     "frame-benchmarking/runtime-benchmarks",
     "pallet-assets/runtime-benchmarks",
     "pallet-xcm/runtime-benchmarks",
     "staging-xcm-builder/runtime-benchmarks",
+    "cumulus-pallet-dmp-queue/runtime-benchmarks",
+    "cumulus-pallet-xcmp-queue/runtime-benchmarks",
+    "cumulus-primitives-core/runtime-benchmarks",
+    "frame-support/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
+    "pallet-balances/runtime-benchmarks",
+    "parachains-common/runtime-benchmarks",
+    "polkadot-parachain-primitives/runtime-benchmarks",
+    "polkadot-runtime-parachains/runtime-benchmarks",
+    "sp-runtime/runtime-benchmarks",
+    "staging-xcm-executor/runtime-benchmarks",
 ]
-try-runtime = ["frame-support/try-runtime"]
+try-runtime = [
+    "frame-support/try-runtime",
+    "cumulus-pallet-dmp-queue/try-runtime",
+    "cumulus-pallet-xcmp-queue/try-runtime",
+    "frame-system/try-runtime",
+    "pallet-assets/try-runtime",
+    "pallet-balances/try-runtime",
+    "pallet-xcm/try-runtime",
+    "polkadot-runtime-parachains/try-runtime",
+    "sp-runtime/try-runtime",
+    "staging-parachain-info/try-runtime",
+]

--- a/claims/Cargo.toml
+++ b/claims/Cargo.toml
@@ -49,6 +49,10 @@ std = [
     "sp-io/std",
     "sp-runtime/std",
     "sp-std/std",
+    "libsecp256k1?/std",
+    "pallet-vesting/std",
+    "serde_json/std",
+    "sp-core/std",
 ]
 runtime-benchmarks = [
     "frame-benchmarking/runtime-benchmarks",
@@ -56,6 +60,15 @@ runtime-benchmarks = [
     "frame-system/runtime-benchmarks",
     "libsecp256k1/hmac",
     "libsecp256k1/static-context",
+    "pallet-balances/runtime-benchmarks",
+    "pallet-vesting/runtime-benchmarks",
+    "sp-runtime/runtime-benchmarks",
 ]
 
-try-runtime = ["frame-support/try-runtime"]
+try-runtime = [
+    "frame-support/try-runtime",
+    "frame-system/try-runtime",
+    "pallet-balances/try-runtime",
+    "pallet-vesting/try-runtime",
+    "sp-runtime/try-runtime",
+]

--- a/enclave-bridge/Cargo.toml
+++ b/enclave-bridge/Cargo.toml
@@ -61,6 +61,9 @@ std = [
     "sp-runtime/std",
     "sp-std/std",
     "teerex-primitives/std",
+    "pallet-balances?/std",
+    "sp-externalities/std",
+    "sp-keyring/std",
 ]
 runtime-benchmarks = [
     "frame-benchmarking/runtime-benchmarks",
@@ -69,9 +72,17 @@ runtime-benchmarks = [
     "pallet-timestamp/runtime-benchmarks",
     "test-utils",
     "pallet-teerex/runtime-benchmarks",
+    "frame-support/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
+    "pallet-balances?/runtime-benchmarks",
+    "sp-runtime/runtime-benchmarks",
 ]
 
 try-runtime = [
     "frame-support/try-runtime",
     "pallet-teerex/try-runtime",
+    "frame-system/try-runtime",
+    "pallet-balances?/try-runtime",
+    "pallet-timestamp/try-runtime",
+    "sp-runtime/try-runtime",
 ]

--- a/parentchain/Cargo.toml
+++ b/parentchain/Cargo.toml
@@ -41,6 +41,12 @@ std = [
     "sp-io/std",
     "sp-runtime/std",
     "sp-std/std",
+    "sp-keyring/std",
 ]
 
-try-runtime = ["frame-support/try-runtime"]
+try-runtime = [
+    "frame-support/try-runtime",
+    "frame-system/try-runtime",
+    "pallet-balances/try-runtime",
+    "sp-runtime/try-runtime",
+]

--- a/primitives/enclave-bridge/Cargo.toml
+++ b/primitives/enclave-bridge/Cargo.toml
@@ -34,4 +34,5 @@ std = [
     "sp-io/std",
     "sp-runtime/std",
     "sp-std/std",
+    "log/std",
 ]

--- a/primitives/xcm-transactor/Cargo.toml
+++ b/primitives/xcm-transactor/Cargo.toml
@@ -34,4 +34,5 @@ std = [
     "parity-scale-codec/std",
     "sp-std/std",
     "staging-xcm/std",
+    "sp-runtime/std",
 ]

--- a/sidechain/Cargo.toml
+++ b/sidechain/Cargo.toml
@@ -65,6 +65,9 @@ std = [
     "sp-runtime/std",
     "sp-std/std",
     "teerex-primitives/std",
+    "pallet-balances?/std",
+    "sp-externalities/std",
+    "sp-keyring/std",
 ]
 runtime-benchmarks = [
     "frame-benchmarking/runtime-benchmarks",
@@ -74,10 +77,18 @@ runtime-benchmarks = [
     "test-utils",
     "pallet-enclave-bridge/runtime-benchmarks",
     "pallet-teerex/runtime-benchmarks",
+    "frame-support/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
+    "pallet-balances?/runtime-benchmarks",
+    "sp-runtime/runtime-benchmarks",
 ]
 
 try-runtime = [
     "frame-support/try-runtime",
     "pallet-enclave-bridge/try-runtime",
     "pallet-teerex/try-runtime",
+    "frame-system/try-runtime",
+    "pallet-balances?/try-runtime",
+    "pallet-timestamp/try-runtime",
+    "sp-runtime/try-runtime",
 ]

--- a/teeracle/Cargo.toml
+++ b/teeracle/Cargo.toml
@@ -62,6 +62,10 @@ std = [
     "substrate-fixed/std",
     "teeracle-primitives/std",
     "teerex-primitives/std",
+    "pallet-balances/std",
+    "pallet-timestamp?/std",
+    "sp-externalities/std",
+    "sp-keyring/std",
 ]
 runtime-benchmarks = [
     "frame-benchmarking/runtime-benchmarks",
@@ -69,9 +73,17 @@ runtime-benchmarks = [
     "pallet-timestamp/runtime-benchmarks",
     "test-utils",
     "pallet-teerex/runtime-benchmarks",
+    "frame-support/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
+    "pallet-balances/runtime-benchmarks",
+    "sp-runtime/runtime-benchmarks",
 ]
 
 try-runtime = [
     "frame-support/try-runtime",
     "pallet-teerex/try-runtime",
+    "frame-system/try-runtime",
+    "pallet-balances/try-runtime",
+    "pallet-timestamp?/try-runtime",
+    "sp-runtime/try-runtime",
 ]

--- a/teerex/Cargo.toml
+++ b/teerex/Cargo.toml
@@ -64,6 +64,11 @@ std = [
     "sp-std/std",
     "teerex-primitives/std",
     "webpki/std",
+    "hex/std",
+    "pallet-balances?/std",
+    "serde_json/std",
+    "sp-externalities/std",
+    "sp-keyring/std",
 ]
 runtime-benchmarks = [
     "frame-benchmarking/runtime-benchmarks",
@@ -71,6 +76,16 @@ runtime-benchmarks = [
     "pallet-balances",
     "pallet-timestamp/runtime-benchmarks",
     "test-utils",
+    "frame-support/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
+    "pallet-balances?/runtime-benchmarks",
+    "sp-runtime/runtime-benchmarks",
 ]
 
-try-runtime = ["frame-support/try-runtime"]
+try-runtime = [
+    "frame-support/try-runtime",
+    "frame-system/try-runtime",
+    "pallet-balances?/try-runtime",
+    "pallet-timestamp/try-runtime",
+    "sp-runtime/try-runtime",
+]

--- a/xcm-transactor/Cargo.toml
+++ b/xcm-transactor/Cargo.toml
@@ -61,7 +61,22 @@ std = [
     "sp-std/std",
     "xcm-transactor-primitives/std",
     "staging-xcm/std",
+    "pallet-balances/std",
+    "sp-externalities/std",
+    "sp-keyring/std",
 ]
-runtime-benchmarks = ["frame-benchmarking/runtime-benchmarks"]
+runtime-benchmarks = [
+    "frame-benchmarking/runtime-benchmarks",
+    "cumulus-primitives-core/runtime-benchmarks",
+    "frame-support/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
+    "pallet-balances/runtime-benchmarks",
+    "sp-runtime/runtime-benchmarks",
+]
 
-try-runtime = ["frame-support/try-runtime"]
+try-runtime = [
+    "frame-support/try-runtime",
+    "frame-system/try-runtime",
+    "pallet-balances/try-runtime",
+    "sp-runtime/try-runtime",
+]


### PR DESCRIPTION
This was needed anyhow to fix the build with the `runtime-benchmark` feature in the polkadot-v1.12.0 branch