### PR TITLE
fix premature unlock with bond_extra

### DIFF
--- a/teerdays/src/lib.rs
+++ b/teerdays/src/lib.rs
@@ -201,6 +201,7 @@ pub mod pallet {
 			#[pallet::compact] value: BalanceOf<T>,
 		) -> DispatchResult {
 			let signer = ensure_signed(origin)?;
+			ensure!(Self::pending_unlock(&signer).is_none(), Error::<T>::PendingUnlock);
 			ensure!(value >= T::Currency::minimum_balance(), Error::<T>::InsufficientBond);
 			let bond = Self::do_update_teerdays(&signer)?;
 			let free_balance = T::Currency::free_balance(&signer);


### PR DESCRIPTION
we can't allow bond_extra during unlocking period - or we need to change the math to calculate the new lock value. Otherwise, the lock will be too low after bond_extra

(UI already disables this)