### PR TITLE
[CI] bump artifact actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         run: cargo +stable about generate about.hbs > license.html
 
       - name: Archive license file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: license
           path: license.html


### PR DESCRIPTION
v3 is deprecated and will be removed on the 30.01.2025.