### PR TITLE
Ab/porteer optimize compact

### DIFF
--- a/porteer/src/lib.rs
+++ b/porteer/src/lib.rs
@@ -389,7 +389,7 @@ pub mod pallet {
 		#[pallet::weight(< T as Config >::WeightInfo::port_tokens())]
 		pub fn port_tokens(
 			origin: OriginFor<T>,
-			amount: BalanceOf<T>,
+			#[pallet::compact] amount: BalanceOf<T>,
 			forward_tokens_to_location: Option<T::Location>,
 		) -> DispatchResult {
 			let signer = ensure_signed(origin)?;
@@ -448,7 +448,7 @@ pub mod pallet {
 		pub fn mint_ported_tokens(
 			origin: OriginFor<T>,
 			beneficiary: AccountIdOf<T>,
-			amount: BalanceOf<T>,
+			#[pallet::compact] amount: BalanceOf<T>,
 			forward_tokens_to_location: Option<T::Location>,
 			#[pallet::compact] source_nonce: PortTokensNonceOf<T>,
 		) -> DispatchResult {

--- a/porteer/src/lib.rs
+++ b/porteer/src/lib.rs
@@ -39,7 +39,7 @@ pub mod weights;
 pub use crate::weights::WeightInfo;
 use frame_support::{transactional, Parameter};
 pub use pallet::*;
-use parity_scale_codec::MaxEncodedLen;
+use parity_scale_codec::{DecodeWithMemTracking, HasCompact, MaxEncodedLen};
 use sp_runtime::{
 	traits::{AtLeast32BitUnsigned, MaybeSerializeDeserialize, Member},
 	DispatchError,
@@ -450,7 +450,7 @@ pub mod pallet {
 			beneficiary: AccountIdOf<T>,
 			amount: BalanceOf<T>,
 			forward_tokens_to_location: Option<T::Location>,
-			source_nonce: PortTokensNonceOf<T>,
+			#[pallet::compact] source_nonce: PortTokensNonceOf<T>,
 		) -> DispatchResult {
 			let _signer = T::TokenSenderLocationOrigin::ensure_origin(origin)?;
 
@@ -499,6 +499,7 @@ pub trait PortTokens {
 		+ Default
 		+ Copy
 		+ MaybeSerializeDeserialize
+		+ HasCompact<Type: DecodeWithMemTracking>
 		+ MaxEncodedLen;
 
 	type Location;


### PR DESCRIPTION
the nonce and the balances arguments can and should be compact encoded

XcmFeeParams has compact fields but can't derive compact because only single-field structs could derive that. Maybe it works anyway? If not, no big harm done